### PR TITLE
fix(renderer): style link labels

### DIFF
--- a/markdown-reader/README.md
+++ b/markdown-reader/README.md
@@ -60,7 +60,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Linebreak handling
 - [x] Rule
 - [x] Tasklists
-- [ ] Links
+- [x] Links
 - [ ] Images
 - [x] Metadata blocks
 - [x] Superscript

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -47,7 +47,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Rule
 - [ ] Tables
 - [x] Tasklists
-- [ ] Links
+- [x] Links
 - [ ] Images
 - [x] Metadata blocks
 - [x] Superscript
@@ -55,6 +55,9 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 
 Linebreaks are rendered with Markdown defaults: soft breaks become spaces, hard breaks insert a
 new line.
+
+Links are rendered as `label (URL)`. The link style applies to both the visible label and URL while
+preserving nested inline formatting such as bold text.
 
 Metadata blocks are rendered using the metadata block style so front matter is visible, including
 the delimiter lines (for example `---` in YAML-style blocks).

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -1038,7 +1038,7 @@ mod tests {
     }
 
     #[rstest]
-    fn link(_with_tracing: DefaultGuard) {
+    fn link_uses_default_style(_with_tracing: DefaultGuard) {
         let link_style = Style::new().blue().underlined();
         assert_eq!(
             from_str("[Link](https://example.com)"),
@@ -1051,43 +1051,17 @@ mod tests {
         );
     }
 
-    mod link_styling {
-        use pretty_assertions::assert_eq;
-
-        use super::*;
-
-        #[rstest]
-        fn link_text_is_styled(_with_tracing: DefaultGuard) {
-            let link_style = Style::new().blue().underlined();
-            let text = from_str("[Click here](https://example.com)");
-            let line = &text.lines[0];
-            // The link text "Click here" should have the link style.
-            let text_span = line
-                .spans
-                .iter()
-                .find(|span| span.content.contains("Click here"))
-                .expect("link text span");
-            assert_eq!(text_span.style, link_style);
-        }
-
-        #[rstest]
-        fn bold_inside_link(_with_tracing: DefaultGuard) {
-            let text = from_str("[**Bold link**](https://example.com)");
-            let line = &text.lines[0];
-            // The bold link text should combine bold + link styles.
-            let bold_span = line
-                .spans
-                .iter()
-                .find(|span| span.content.contains("Bold link"))
-                .expect("bold link span");
-            assert!(bold_span
-                .style
-                .add_modifier
-                .contains(ratatui_core::style::Modifier::BOLD));
-            assert!(bold_span
-                .style
-                .add_modifier
-                .contains(ratatui_core::style::Modifier::UNDERLINED));
-        }
+    #[rstest]
+    fn link_combines_with_bold_style(_with_tracing: DefaultGuard) {
+        let link_style = Style::new().blue().underlined();
+        assert_eq!(
+            from_str("[**Bold link**](https://example.com)"),
+            Text::from(Line::from_iter([
+                Span::styled("Bold link", link_style.bold()),
+                Span::from(" ("),
+                Span::styled("https://example.com", link_style),
+                Span::from(")"),
+            ]))
+        );
     }
 }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -572,15 +572,17 @@ where
         }
     }
 
-    /// Store the link to be appended to the link text
+    /// Store the link and push the link style so the link text is also styled.
     #[instrument(level = "trace", skip(self))]
     fn push_link(&mut self, dest_url: CowStr<'a>) {
         self.link = Some(dest_url);
+        self.push_inline_style(self.styles.link());
     }
 
-    /// Append the link to the current line
+    /// Pop the link style and append the link URL to the current line.
     #[instrument(level = "trace", skip(self))]
     fn pop_link(&mut self) {
+        self.pop_inline_style();
         if let Some(link) = self.link.take() {
             self.push_span(" (".into());
             self.push_span(Span::styled(link, self.styles.link()));
@@ -1037,14 +1039,55 @@ mod tests {
 
     #[rstest]
     fn link(_with_tracing: DefaultGuard) {
+        let link_style = Style::new().blue().underlined();
         assert_eq!(
             from_str("[Link](https://example.com)"),
             Text::from(Line::from_iter([
-                Span::from("Link"),
+                Span::styled("Link", link_style),
                 Span::from(" ("),
-                Span::from("https://example.com").blue().underlined(),
+                Span::styled("https://example.com", link_style),
                 Span::from(")")
             ]))
         );
+    }
+
+    mod link_styling {
+        use pretty_assertions::assert_eq;
+
+        use super::*;
+
+        #[rstest]
+        fn link_text_is_styled(_with_tracing: DefaultGuard) {
+            let link_style = Style::new().blue().underlined();
+            let text = from_str("[Click here](https://example.com)");
+            let line = &text.lines[0];
+            // The link text "Click here" should have the link style.
+            let text_span = line
+                .spans
+                .iter()
+                .find(|span| span.content.contains("Click here"))
+                .expect("link text span");
+            assert_eq!(text_span.style, link_style);
+        }
+
+        #[rstest]
+        fn bold_inside_link(_with_tracing: DefaultGuard) {
+            let text = from_str("[**Bold link**](https://example.com)");
+            let line = &text.lines[0];
+            // The bold link text should combine bold + link styles.
+            let bold_span = line
+                .spans
+                .iter()
+                .find(|span| span.content.contains("Bold link"))
+                .expect("bold link span");
+            assert!(bold_span
+                .style
+                .add_modifier
+                .contains(ratatui_core::style::Modifier::BOLD));
+            assert!(bold_span
+                .style
+                .add_modifier
+                .contains(ratatui_core::style::Modifier::UNDERLINED));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Apply the configured link style to the visible Markdown link label as well as the appended destination. Nested formatting such as bold text continues to compose with the link style.

## Example

```rust
let text = tui_markdown::from_str("[Ratatui](https://ratatui.rs)");
```

This renders `Ratatui (https://ratatui.rs)`, with both the label and URL styled by `StyleSheet::link()`.

## Documentation and tests

- Marks links as supported in the library and reader documentation.
- Documents the rendered `label (URL)` form.
- Uses separate exact output assertions for the default link style and an added bold style.

## Attribution

Originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125).

## Validation

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, warning-denied documentation builds, and Markdown linting.
