### PR TITLE
feat(renderer): render raw HTML

### DIFF
--- a/markdown-reader/README.md
+++ b/markdown-reader/README.md
@@ -54,7 +54,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Ordered lists
 - [x] Unordered lists
 - [x] Code blocks
-- [ ] Html
+- [x] HTML
 - [ ] Footnotes
 - [ ] Tables
 - [x] Linebreak handling

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -41,7 +41,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Ordered lists
 - [x] Unordered lists
 - [x] Code blocks
-- [ ] Html
+- [x] HTML
 - [ ] Footnotes
 - [x] Linebreak handling
 - [x] Rule
@@ -58,6 +58,9 @@ new line.
 
 Links are rendered as `label (URL)`. The link style applies to both the visible label and URL while
 preserving nested inline formatting such as bold text.
+
+Raw inline HTML tags and HTML blocks are displayed literally rather than interpreted as terminal
+markup. They are dimmed by default and can be customized with [`StyleSheet::html()`].
 
 Metadata blocks are rendered using the metadata block style so front matter is visible, including
 the delimiter lines (for example `---` in YAML-style blocks).
@@ -116,6 +119,7 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md).
 [tui-markdown]: https://crates.io/crates/tui-markdown
 [markdown-reader]: https://crates.io/crates/markdown-reader
 [Ratatui]: https://crates.io/crates/ratatui
+[`StyleSheet::html()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.html
 
 [Crate badge]: https://img.shields.io/crates/v/tui-markdown?logo=rust&style=for-the-badge
 [Docs.rs Badge]: https://img.shields.io/docsrs/tui-markdown?logo=rust&style=for-the-badge

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -1103,17 +1103,29 @@ mod tests {
 
         #[rstest]
         fn inline_html_tag(_with_tracing: DefaultGuard) {
-            let text = from_str("Hello <em>world</em>");
-            // Inline HTML tags are rendered as dim text alongside normal text.
-            assert_eq!(text.lines.len(), 1);
-            assert!(text.lines[0].spans.len() >= 2);
+            assert_eq!(
+                from_str("Hello <em>world</em>"),
+                Text::from(Line::from_iter([
+                    Span::from("Hello "),
+                    Span::styled("<em>", Style::new().dim()),
+                    Span::from("world"),
+                    Span::styled("</em>", Style::new().dim()),
+                ]))
+            );
         }
 
         #[rstest]
         fn html_block_renders(_with_tracing: DefaultGuard) {
-            let text = from_str("<div>Custom HTML</div>\n");
-            // HTML blocks should render something (not be silently dropped).
-            assert!(!text.lines.is_empty());
+            assert_eq!(
+                from_str("<div>\nCustom HTML\n</div>\n"),
+                Text::from_iter([
+                    Line::from(Span::styled("<div>", Style::new().dim())),
+                    Line::from(Span::styled("Custom HTML", Style::new().dim()))
+                        .style(Style::new().dim()),
+                    Line::from(Span::styled("</div>", Style::new().dim()))
+                        .style(Style::new().dim()),
+                ])
+            );
         }
     }
 }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -225,8 +225,8 @@ where
             Event::End(tag) => self.end_tag(tag),
             Event::Text(text) => self.text(text),
             Event::Code(code) => self.code(code),
-            Event::Html(_) => warn!("Html not yet supported"),
-            Event::InlineHtml(_) => warn!("Inline html not yet supported"),
+            Event::Html(html) => self.html_block(html),
+            Event::InlineHtml(html) => self.inline_html(html),
             Event::FootnoteReference(_) => warn!("Footnote reference not yet supported"),
             Event::SoftBreak => self.soft_break(),
             Event::HardBreak => self.hard_break(),
@@ -248,7 +248,7 @@ where
             } => self.start_heading(level, HeadingMeta { id, classes, attrs }),
             Tag::BlockQuote(kind) => self.start_blockquote(kind),
             Tag::CodeBlock(kind) => self.start_codeblock(kind),
-            Tag::HtmlBlock => warn!("Html block not yet supported"),
+            Tag::HtmlBlock => self.start_html_block(),
             Tag::List(start_index) => self.start_list(start_index),
             Tag::Item => self.start_item(),
             Tag::FootnoteDefinition(_) => warn!("Footnote definition not yet supported"),
@@ -276,7 +276,7 @@ where
             TagEnd::Heading(_) => self.end_heading(),
             TagEnd::BlockQuote(_) => self.end_blockquote(),
             TagEnd::CodeBlock => self.end_codeblock(),
-            TagEnd::HtmlBlock => {}
+            TagEnd::HtmlBlock => self.end_html_block(),
             TagEnd::List(_is_ordered) => self.end_list(),
             TagEnd::Item => {}
             TagEnd::FootnoteDefinition => {}
@@ -588,6 +588,37 @@ where
             self.push_span(Span::styled(link, self.styles.link()));
             self.push_span(")".into());
         }
+    }
+
+    fn start_html_block(&mut self) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        self.push_line(Line::default());
+        self.line_styles.push(self.styles.html());
+        self.needs_newline = false;
+    }
+
+    fn end_html_block(&mut self) {
+        self.line_styles.pop();
+        self.needs_newline = true;
+    }
+
+    fn html_block(&mut self, html: CowStr<'a>) {
+        let style = self.styles.html();
+        for line in html.lines() {
+            if self.needs_newline {
+                self.push_line(Line::default());
+                self.needs_newline = false;
+            }
+            self.push_span(Span::styled(line.to_owned(), style));
+            self.needs_newline = true;
+        }
+    }
+
+    fn inline_html(&mut self, html: CowStr<'a>) {
+        let style = self.styles.html();
+        self.push_span(Span::styled(html, style));
     }
 }
 
@@ -1063,5 +1094,26 @@ mod tests {
                 Span::from(")"),
             ]))
         );
+    }
+
+    mod html {
+        use pretty_assertions::assert_eq;
+
+        use super::*;
+
+        #[rstest]
+        fn inline_html_tag(_with_tracing: DefaultGuard) {
+            let text = from_str("Hello <em>world</em>");
+            // Inline HTML tags are rendered as dim text alongside normal text.
+            assert_eq!(text.lines.len(), 1);
+            assert!(text.lines[0].spans.len() >= 2);
+        }
+
+        #[rstest]
+        fn html_block_renders(_with_tracing: DefaultGuard) {
+            let text = from_str("<div>Custom HTML</div>\n");
+            // HTML blocks should render something (not be silently dropped).
+            assert!(!text.lines.is_empty());
+        }
     }
 }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -617,7 +617,8 @@ where
     }
 
     fn inline_html(&mut self, html: CowStr<'a>) {
-        let style = self.styles.html();
+        let inline_style = self.inline_styles.last().copied().unwrap_or_default();
+        let style = inline_style.patch(self.styles.html());
         self.push_span(Span::styled(html, style));
     }
 }
@@ -1115,15 +1116,34 @@ mod tests {
         }
 
         #[rstest]
-        fn html_block_renders(_with_tracing: DefaultGuard) {
+        fn inline_html_combines_with_emphasis(_with_tracing: DefaultGuard) {
+            let italic = Style::new().italic();
+            let html = italic.dim();
             assert_eq!(
-                from_str("<div>\nCustom HTML\n</div>\n"),
+                from_str("*Hello <em>world</em>*"),
+                Text::from(Line::from_iter([
+                    Span::styled("Hello ", italic),
+                    Span::styled("<em>", html),
+                    Span::styled("world", italic),
+                    Span::styled("</em>", html),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn html_block_preserves_paragraph_spacing(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Before\n\n<div>\nCustom HTML\n</div>\n\nAfter"),
                 Text::from_iter([
+                    Line::from("Before"),
+                    Line::default(),
                     Line::from(Span::styled("<div>", Style::new().dim())),
                     Line::from(Span::styled("Custom HTML", Style::new().dim()))
                         .style(Style::new().dim()),
                     Line::from(Span::styled("</div>", Style::new().dim()))
                         .style(Style::new().dim()),
+                    Line::default(),
+                    Line::from("After"),
                 ])
             );
         }

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -37,6 +37,11 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 
     /// Style for metadata blocks (front matter).
     fn metadata_block(&self) -> Style;
+
+    /// Style for raw HTML blocks and inline HTML tags.
+    fn html(&self) -> Style {
+        Style::new().dim()
+    }
 }
 
 /// The default style set

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -57,6 +57,7 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 /// - link: blue, underlined
 /// - blockquote: green
 /// - metadata block: light yellow
+/// - raw HTML: dim
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DefaultStyleSheet;
 


### PR DESCRIPTION
## Summary

Render inline and block HTML literally instead of silently discarding it. Raw tags remain visible in terminal output and use a dim default style.

## Example

```rust
let text = tui_markdown::from_str("Press <kbd>q</kbd> to quit.");
```

The `<kbd>` and `</kbd>` tags remain visible and use `StyleSheet::html()`. When raw HTML appears inside emphasis or another inline style, the styles compose.

## Documentation and tests

- Marks HTML as supported and documents that it is displayed literally rather than interpreted.
- Adds a source-compatible `StyleSheet::html()` hook with a dim default.
- Covers inline nesting and paragraph/HTML-block spacing with exact output tests.

## Attribution

Originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125), with maintainer follow-up for style composition and block boundaries.

## Validation

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, warning-denied documentation builds, and Markdown linting.
