### PR TITLE
feat(renderer): render math

### DIFF
--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -42,6 +42,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Unordered lists
 - [x] Code blocks
 - [x] HTML
+- [x] Math
 - [ ] Footnotes
 - [x] Linebreak handling
 - [x] Rule
@@ -61,6 +62,11 @@ preserving nested inline formatting such as bold text.
 
 Raw inline HTML tags and HTML blocks are displayed literally rather than interpreted as terminal
 markup. They are dimmed by default and can be customized with [`StyleSheet::html()`].
+
+Inline and display math keep their `$...$` and `$$...$$` delimiters visible. Inline math is
+magenta and italic by default, while display math is magenta and preserves multiline formulas as
+separate terminal lines. Customize these styles with [`StyleSheet::math_inline()`] and
+[`StyleSheet::math_display()`].
 
 Metadata blocks are rendered using the metadata block style so front matter is visible, including
 the delimiter lines (for example `---` in YAML-style blocks).
@@ -120,6 +126,8 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md).
 [markdown-reader]: https://crates.io/crates/markdown-reader
 [Ratatui]: https://crates.io/crates/ratatui
 [`StyleSheet::html()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.html
+[`StyleSheet::math_display()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.math_display
+[`StyleSheet::math_inline()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.math_inline
 
 [Crate badge]: https://img.shields.io/crates/v/tui-markdown?logo=rust&style=for-the-badge
 [Docs.rs Badge]: https://img.shields.io/docsrs/tui-markdown?logo=rust&style=for-the-badge

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -623,7 +623,8 @@ where
     }
 
     fn inline_math(&mut self, math: CowStr<'a>) {
-        let style = self.styles.math_inline();
+        let inline_style = self.inline_styles.last().copied().unwrap_or_default();
+        let style = inline_style.patch(self.styles.math_inline());
         self.push_span(Span::styled(format!("${math}$"), style));
     }
 
@@ -632,8 +633,13 @@ where
             self.push_line(Line::default());
         }
         let style = self.styles.math_display();
-        self.push_line(Line::default());
-        self.push_span(Span::styled(format!("$${math}$$"), style));
+        let display_math = format!("$${math}$$");
+        for (index, line) in display_math.lines().enumerate() {
+            if index > 0 {
+                self.push_line(Line::default());
+            }
+            self.push_span(Span::styled(line.to_owned(), style));
+        }
         self.needs_newline = true;
     }
 }
@@ -1170,40 +1176,90 @@ mod tests {
         use super::*;
 
         #[rstest]
-        fn inline_math_renders(_with_tracing: DefaultGuard) {
-            let text = from_str("The formula $E=mc^2$ is famous.");
-            let line = &text.lines[0];
-            // Should contain the math text styled with magenta italic.
-            let math_span = line
-                .spans
-                .iter()
-                .find(|span| span.content.contains("E=mc^2"))
-                .expect("math span should exist");
-            assert_eq!(math_span.style, Style::new().italic().fg(Color::Magenta));
+        fn inline_math_has_exact_output_and_style(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("The formula $E=mc^2$ is famous."),
+                Text::from(Line::from_iter([
+                    Span::raw("The formula "),
+                    Span::styled("$E=mc^2$", Style::new().italic().fg(Color::Magenta)),
+                    Span::raw(" is famous."),
+                ]))
+            );
         }
 
         #[rstest]
-        fn display_math_renders(_with_tracing: DefaultGuard) {
-            let text = from_str("$$\nx^2 + y^2 = z^2\n$$");
-            // Display math should produce output with magenta styling.
-            let has_math = text
-                .lines
-                .iter()
-                .any(|line| line.spans.iter().any(|span| span.content.contains("x^2")));
-            assert!(has_math, "display math should render the formula");
+        fn inline_math_combines_with_enclosing_style(_with_tracing: DefaultGuard) {
+            let style = Style::new().bold().italic().fg(Color::Magenta);
+            assert_eq!(
+                from_str("**$x$**"),
+                Text::from(Line::from(Span::styled("$x$", style)))
+            );
         }
 
         #[rstest]
-        fn inline_math_wrapped_in_dollars(_with_tracing: DefaultGuard) {
-            let text = from_str("$\\alpha$");
-            let line = &text.lines[0];
-            let math_span = line
-                .spans
-                .iter()
-                .find(|span| span.content.contains("\\alpha"))
-                .expect("math span");
-            assert!(math_span.content.starts_with('$'));
-            assert!(math_span.content.ends_with('$'));
+        fn multiline_display_math_styles_every_line(_with_tracing: DefaultGuard) {
+            let style = Style::new().fg(Color::Magenta);
+            assert_eq!(
+                from_str("Before\n\n$$\nx = y\ny = z\n$$\n\nAfter"),
+                Text::from_iter([
+                    Line::from("Before"),
+                    Line::default(),
+                    Line::from(Span::styled("$$", style)),
+                    Line::from(Span::styled("x = y", style)),
+                    Line::from(Span::styled("y = z", style)),
+                    Line::from(Span::styled("$$", style)),
+                    Line::default(),
+                    Line::from("After"),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiline_display_math_uses_custom_style(_with_tracing: DefaultGuard) {
+            #[derive(Clone, Copy)]
+            struct CustomMathStyle;
+
+            impl StyleSheet for CustomMathStyle {
+                fn heading(&self, level: u8) -> Style {
+                    DefaultStyleSheet.heading(level)
+                }
+
+                fn code(&self) -> Style {
+                    DefaultStyleSheet.code()
+                }
+
+                fn link(&self) -> Style {
+                    DefaultStyleSheet.link()
+                }
+
+                fn blockquote(&self) -> Style {
+                    DefaultStyleSheet.blockquote()
+                }
+
+                fn heading_meta(&self) -> Style {
+                    DefaultStyleSheet.heading_meta()
+                }
+
+                fn metadata_block(&self) -> Style {
+                    DefaultStyleSheet.metadata_block()
+                }
+
+                fn math_display(&self) -> Style {
+                    Style::new().red().bold()
+                }
+            }
+
+            let style = Style::new().red().bold();
+            let options = Options::new(CustomMathStyle);
+            assert_eq!(
+                from_str_with_options("$$\nx = y\ny = z\n$$", &options),
+                Text::from_iter([
+                    Line::from(Span::styled("$$", style)),
+                    Line::from(Span::styled("x = y", style)),
+                    Line::from(Span::styled("y = z", style)),
+                    Line::from(Span::styled("$$", style)),
+                ])
+            );
         }
     }
 }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -90,6 +90,7 @@ where
     parse_opts.insert(ParseOptions::ENABLE_YAML_STYLE_METADATA_BLOCKS);
     parse_opts.insert(ParseOptions::ENABLE_SUPERSCRIPT);
     parse_opts.insert(ParseOptions::ENABLE_SUBSCRIPT);
+    parse_opts.insert(ParseOptions::ENABLE_MATH);
     let parser = Parser::new_ext(input, parse_opts);
 
     let mut writer = TextWriter::new(parser, options.styles.clone());
@@ -232,8 +233,8 @@ where
             Event::HardBreak => self.hard_break(),
             Event::Rule => self.rule(),
             Event::TaskListMarker(checked) => self.task_list_marker(checked),
-            Event::InlineMath(_) => warn!("Inline math not yet supported"),
-            Event::DisplayMath(_) => warn!("Display math not yet supported"),
+            Event::InlineMath(math) => self.inline_math(math),
+            Event::DisplayMath(math) => self.display_math(math),
         }
     }
 
@@ -589,7 +590,6 @@ where
             self.push_span(")".into());
         }
     }
-
     fn start_html_block(&mut self) {
         if self.needs_newline {
             self.push_line(Line::default());
@@ -620,6 +620,21 @@ where
         let inline_style = self.inline_styles.last().copied().unwrap_or_default();
         let style = inline_style.patch(self.styles.html());
         self.push_span(Span::styled(html, style));
+    }
+
+    fn inline_math(&mut self, math: CowStr<'a>) {
+        let style = self.styles.math_inline();
+        self.push_span(Span::styled(format!("${math}$"), style));
+    }
+
+    fn display_math(&mut self, math: CowStr<'a>) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        let style = self.styles.math_display();
+        self.push_line(Line::default());
+        self.push_span(Span::styled(format!("$${math}$$"), style));
+        self.needs_newline = true;
     }
 }
 
@@ -1082,7 +1097,6 @@ mod tests {
             ]))
         );
     }
-
     #[rstest]
     fn link_combines_with_bold_style(_with_tracing: DefaultGuard) {
         let link_style = Style::new().blue().underlined();
@@ -1146,6 +1160,50 @@ mod tests {
                     Line::from("After"),
                 ])
             );
+        }
+    }
+
+    mod math {
+        use pretty_assertions::assert_eq;
+        use ratatui_core::style::Color;
+
+        use super::*;
+
+        #[rstest]
+        fn inline_math_renders(_with_tracing: DefaultGuard) {
+            let text = from_str("The formula $E=mc^2$ is famous.");
+            let line = &text.lines[0];
+            // Should contain the math text styled with magenta italic.
+            let math_span = line
+                .spans
+                .iter()
+                .find(|span| span.content.contains("E=mc^2"))
+                .expect("math span should exist");
+            assert_eq!(math_span.style, Style::new().italic().fg(Color::Magenta));
+        }
+
+        #[rstest]
+        fn display_math_renders(_with_tracing: DefaultGuard) {
+            let text = from_str("$$\nx^2 + y^2 = z^2\n$$");
+            // Display math should produce output with magenta styling.
+            let has_math = text
+                .lines
+                .iter()
+                .any(|line| line.spans.iter().any(|span| span.content.contains("x^2")));
+            assert!(has_math, "display math should render the formula");
+        }
+
+        #[rstest]
+        fn inline_math_wrapped_in_dollars(_with_tracing: DefaultGuard) {
+            let text = from_str("$\\alpha$");
+            let line = &text.lines[0];
+            let math_span = line
+                .spans
+                .iter()
+                .find(|span| span.content.contains("\\alpha"))
+                .expect("math span");
+            assert!(math_span.content.starts_with('$'));
+            assert!(math_span.content.ends_with('$'));
         }
     }
 }

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -67,6 +67,8 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 /// - blockquote: green
 /// - metadata block: light yellow
 /// - raw HTML: dim
+/// - inline math: magenta, italic
+/// - display math: magenta
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DefaultStyleSheet;
 

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -37,10 +37,19 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 
     /// Style for metadata blocks (front matter).
     fn metadata_block(&self) -> Style;
-
     /// Style for raw HTML blocks and inline HTML tags.
     fn html(&self) -> Style {
         Style::new().dim()
+    }
+
+    /// Style for inline math (`$...$`).
+    fn math_inline(&self) -> Style {
+        Style::new().italic().magenta()
+    }
+
+    /// Style for display math (`$$...$$`).
+    fn math_display(&self) -> Style {
+        Style::new().magenta()
     }
 }
 


### PR DESCRIPTION
## Summary

Render inline and display math as visible, independently styled content. Inline math remains in the surrounding line, while multiline display math is represented by real Ratatui lines rather than embedded newline characters.

## Example

```markdown
Energy is $E = mc^2$.

$$
x = y
y = z
$$
```

The delimiters remain visible. Inline math uses `StyleSheet::math_inline()` and display math uses `StyleSheet::math_display()`.

## Documentation and tests

- Documents math support, delimiter behavior, and the default styles.
- Provides source-compatible style hooks for inline and display math.
- Uses exact tests for inline output, nested styles, and multiple display rows under default and custom styles.

## Attribution

Originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125), with a maintainer fix for multiline Ratatui layout and style composition.

## Validation

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, warning-denied documentation builds, and Markdown linting.
