### PR TITLE
feat(renderer): render footnotes

### DIFF
--- a/markdown-reader/README.md
+++ b/markdown-reader/README.md
@@ -55,7 +55,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Unordered lists
 - [x] Code blocks
 - [x] HTML
-- [ ] Footnotes
+- [x] Footnotes
 - [ ] Tables
 - [x] Linebreak handling
 - [x] Rule

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -43,7 +43,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Code blocks
 - [x] HTML
 - [x] Math
-- [ ] Footnotes
+- [x] Footnotes
 - [x] Linebreak handling
 - [x] Rule
 - [ ] Tables
@@ -67,6 +67,10 @@ Inline and display math keep their `$...$` and `$$...$$` delimiters visible. Inl
 magenta and italic by default, while display math is magenta and preserves multiline formulas as
 separate terminal lines. Customize these styles with [`StyleSheet::math_inline()`] and
 [`StyleSheet::math_display()`].
+
+Footnote references such as `[^source]` are displayed as `[source]`, and definitions are displayed
+as `[source]: ...`. References are dim and italic by default, while definitions are dim. Customize
+these styles with [`StyleSheet::footnote_ref()`] and [`StyleSheet::footnote_def()`].
 
 Metadata blocks are rendered using the metadata block style so front matter is visible, including
 the delimiter lines (for example `---` in YAML-style blocks).
@@ -128,6 +132,8 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md).
 [`StyleSheet::html()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.html
 [`StyleSheet::math_display()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.math_display
 [`StyleSheet::math_inline()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.math_inline
+[`StyleSheet::footnote_def()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.footnote_def
+[`StyleSheet::footnote_ref()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.footnote_ref
 
 [Crate badge]: https://img.shields.io/crates/v/tui-markdown?logo=rust&style=for-the-badge
 [Docs.rs Badge]: https://img.shields.io/docsrs/tui-markdown?logo=rust&style=for-the-badge

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -305,7 +305,16 @@ where
     }
 
     fn start_paragraph(&mut self) {
-        if self.in_footnote_definition {
+        // A footnote definition starts with a paragraph event after
+        // `start_footnote_definition` has already written `[label]: ` to the current line. Skip
+        // normal paragraph handling only for that first paragraph so its content stays beside the
+        // label. For a later paragraph, `needs_newline` is true; allowing the normal path below to
+        // run preserves the blank line in definitions such as:
+        //
+        //     [^label]: First paragraph.
+        //
+        //         Second paragraph.
+        if self.in_footnote_definition && !self.needs_newline {
             return;
         }
         // Insert an empty line between paragraphs if there is at least one line of text already.
@@ -652,10 +661,13 @@ where
     }
 
     fn footnote_reference(&mut self, label: CowStr<'a>) {
-        self.push_span(Span::styled(
-            format!("[{label}]"),
-            self.styles.footnote_ref(),
-        ));
+        // A reference can appear inside other inline formatting, as in `**Text[^label]**`.
+        // Styling it with only `footnote_ref()` would make `[label]` dim and italic but drop the
+        // surrounding bold style. Start with the active inline style and patch the footnote style
+        // over it so the reference adds its own appearance without losing enclosing formatting.
+        let inline_style = self.inline_styles.last().copied().unwrap_or_default();
+        let style = inline_style.patch(self.styles.footnote_ref());
+        self.push_span(Span::styled(format!("[{label}]"), style));
     }
 
     fn start_footnote_definition(&mut self, label: CowStr<'a>) {
@@ -743,27 +755,6 @@ mod tests {
         use super::*;
 
         #[rstest]
-        fn footnote_reference_renders(_with_tracing: DefaultGuard) {
-            let text = from_str("Text[^1]\n\n[^1]: The footnote content.");
-            let has_ref = text
-                .lines
-                .iter()
-                .any(|line| line.spans.iter().any(|span| span.content.contains("[1]")));
-            assert!(has_ref, "footnote reference should render as [1]");
-        }
-
-        #[rstest]
-        fn footnote_definition_renders(_with_tracing: DefaultGuard) {
-            let text = from_str("Text[^note]\n\n[^note]: A longer note.");
-            let has_definition = text.lines.iter().any(|line| {
-                line.spans
-                    .iter()
-                    .any(|span| span.content.contains("[note]:"))
-            });
-            assert!(has_definition, "footnote definition should render");
-        }
-
-        #[rstest]
         fn multiline_definition_has_exact_layout(_with_tracing: DefaultGuard) {
             let reference_style = Style::new().dim().italic();
             let definition_style = Style::new().dim();
@@ -807,6 +798,133 @@ mod tests {
                     Line::default(),
                     Line::from_iter([Span::styled("[b]: ", definition_style), Span::raw("Beta."),])
                         .style(definition_style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn reference_combines_with_enclosing_style(_with_tracing: DefaultGuard) {
+            let reference_style = Style::new().bold().dim().italic();
+            assert_eq!(
+                from_str("**Text[^one]**\n\n[^one]: Note."),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::styled("Text", Style::new().bold()),
+                        Span::styled("[one]", reference_style),
+                    ]),
+                    Line::default(),
+                    Line::from_iter([
+                        Span::styled("[one]: ", Style::new().dim()),
+                        Span::raw("Note."),
+                    ])
+                    .style(Style::new().dim()),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiple_definition_paragraphs_keep_blank_line(_with_tracing: DefaultGuard) {
+            let definition_style = Style::new().dim();
+            assert_eq!(
+                from_str("Text[^one]\n\n[^one]: First paragraph.\n\n    Second paragraph."),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw("Text"),
+                        Span::styled("[one]", definition_style.italic()),
+                    ]),
+                    Line::default(),
+                    Line::from_iter([
+                        Span::styled("[one]: ", definition_style),
+                        Span::raw("First paragraph."),
+                    ])
+                    .style(definition_style),
+                    Line::default().style(definition_style),
+                    Line::from("Second paragraph.").style(definition_style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn definition_style_does_not_leak_into_following_paragraph(_with_tracing: DefaultGuard) {
+            let definition_style = Style::new().dim();
+            assert_eq!(
+                from_str(
+                    "Text[^one]\n\n[^one]: First paragraph.\n\n    Second paragraph.\n\nAfter."
+                ),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw("Text"),
+                        Span::styled("[one]", definition_style.italic()),
+                    ]),
+                    Line::default(),
+                    Line::from_iter([
+                        Span::styled("[one]: ", definition_style),
+                        Span::raw("First paragraph."),
+                    ])
+                    .style(definition_style),
+                    Line::default().style(definition_style),
+                    Line::from("Second paragraph.").style(definition_style),
+                    Line::default(),
+                    Line::from("After."),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn custom_styles_compose_with_enclosing_formatting(_with_tracing: DefaultGuard) {
+            #[derive(Clone, Copy)]
+            struct CustomFootnoteStyle;
+
+            impl StyleSheet for CustomFootnoteStyle {
+                fn heading(&self, level: u8) -> Style {
+                    DefaultStyleSheet.heading(level)
+                }
+
+                fn code(&self) -> Style {
+                    DefaultStyleSheet.code()
+                }
+
+                fn link(&self) -> Style {
+                    DefaultStyleSheet.link()
+                }
+
+                fn blockquote(&self) -> Style {
+                    DefaultStyleSheet.blockquote()
+                }
+
+                fn heading_meta(&self) -> Style {
+                    DefaultStyleSheet.heading_meta()
+                }
+
+                fn metadata_block(&self) -> Style {
+                    DefaultStyleSheet.metadata_block()
+                }
+
+                fn footnote_ref(&self) -> Style {
+                    Style::new().red().underlined()
+                }
+
+                fn footnote_def(&self) -> Style {
+                    Style::new().blue().underlined()
+                }
+            }
+
+            let reference_style = Style::new().red().bold().underlined();
+            let definition_style = Style::new().blue().underlined();
+            let options = Options::new(CustomFootnoteStyle);
+            assert_eq!(
+                from_str_with_options("**Text[^one]**\n\n[^one]: Note.", &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::styled("Text", Style::new().bold()),
+                        Span::styled("[one]", reference_style),
+                    ]),
+                    Line::default(),
+                    Line::from_iter([
+                        Span::styled("[one]: ", definition_style),
+                        Span::raw("Note."),
+                    ])
+                    .style(definition_style),
                 ])
             );
         }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -663,9 +663,9 @@ where
             self.push_line(Line::default());
         }
         let style = self.styles.footnote_def();
+        self.line_styles.push(style);
         self.push_line(Line::default());
         self.push_span(Span::styled(format!("[{label}]: "), style));
-        self.line_styles.push(style);
         self.in_footnote_definition = true;
         self.needs_newline = false;
     }
@@ -738,6 +738,8 @@ mod tests {
     }
 
     mod footnotes {
+        use pretty_assertions::assert_eq;
+
         use super::*;
 
         #[rstest]
@@ -759,6 +761,54 @@ mod tests {
                     .any(|span| span.content.contains("[note]:"))
             });
             assert!(has_definition, "footnote definition should render");
+        }
+
+        #[rstest]
+        fn multiline_definition_has_exact_layout(_with_tracing: DefaultGuard) {
+            let reference_style = Style::new().dim().italic();
+            let definition_style = Style::new().dim();
+
+            assert_eq!(
+                from_str("Text[^one]\n\n[^one]: First line\n    continued line."),
+                Text::from_iter([
+                    Line::from_iter([Span::raw("Text"), Span::styled("[one]", reference_style),]),
+                    Line::default(),
+                    Line::from_iter([
+                        Span::styled("[one]: ", definition_style),
+                        Span::raw("First line"),
+                        Span::raw(" "),
+                        Span::raw("continued line."),
+                    ])
+                    .style(definition_style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiple_definitions_have_exact_layout(_with_tracing: DefaultGuard) {
+            let reference_style = Style::new().dim().italic();
+            let definition_style = Style::new().dim();
+
+            assert_eq!(
+                from_str("First[^a] second[^b].\n\n[^a]: Alpha.\n\n[^b]: Beta."),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw("First"),
+                        Span::styled("[a]", reference_style),
+                        Span::raw(" second"),
+                        Span::styled("[b]", reference_style),
+                        Span::raw("."),
+                    ]),
+                    Line::default(),
+                    Line::from_iter(
+                        [Span::styled("[a]: ", definition_style), Span::raw("Alpha."),]
+                    )
+                    .style(definition_style),
+                    Line::default(),
+                    Line::from_iter([Span::styled("[b]: ", definition_style), Span::raw("Beta."),])
+                        .style(definition_style),
+                ])
+            );
         }
     }
 

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -91,6 +91,7 @@ where
     parse_opts.insert(ParseOptions::ENABLE_SUPERSCRIPT);
     parse_opts.insert(ParseOptions::ENABLE_SUBSCRIPT);
     parse_opts.insert(ParseOptions::ENABLE_MATH);
+    parse_opts.insert(ParseOptions::ENABLE_FOOTNOTES);
     let parser = Parser::new_ext(input, parse_opts);
 
     let mut writer = TextWriter::new(parser, options.styles.clone());
@@ -181,6 +182,9 @@ struct TextWriter<'a, I, S: StyleSheet> {
     /// Whether we are inside a metadata block.
     in_metadata_block: bool,
 
+    /// Whether we are inside a footnote definition.
+    in_footnote_definition: bool,
+
     needs_newline: bool,
 }
 
@@ -209,6 +213,7 @@ where
             styles,
             heading_meta: None,
             in_metadata_block: false,
+            in_footnote_definition: false,
         }
     }
 
@@ -228,7 +233,7 @@ where
             Event::Code(code) => self.code(code),
             Event::Html(html) => self.html_block(html),
             Event::InlineHtml(html) => self.inline_html(html),
-            Event::FootnoteReference(_) => warn!("Footnote reference not yet supported"),
+            Event::FootnoteReference(label) => self.footnote_reference(label),
             Event::SoftBreak => self.soft_break(),
             Event::HardBreak => self.hard_break(),
             Event::Rule => self.rule(),
@@ -252,7 +257,7 @@ where
             Tag::HtmlBlock => self.start_html_block(),
             Tag::List(start_index) => self.start_list(start_index),
             Tag::Item => self.start_item(),
-            Tag::FootnoteDefinition(_) => warn!("Footnote definition not yet supported"),
+            Tag::FootnoteDefinition(label) => self.start_footnote_definition(label),
             Tag::Table(_) => warn!("Table not yet supported"),
             Tag::TableHead => warn!("Table head not yet supported"),
             Tag::TableRow => warn!("Table row not yet supported"),
@@ -280,7 +285,7 @@ where
             TagEnd::HtmlBlock => self.end_html_block(),
             TagEnd::List(_is_ordered) => self.end_list(),
             TagEnd::Item => {}
-            TagEnd::FootnoteDefinition => {}
+            TagEnd::FootnoteDefinition => self.end_footnote_definition(),
             TagEnd::Table => {}
             TagEnd::TableHead => {}
             TagEnd::TableRow => {}
@@ -300,6 +305,9 @@ where
     }
 
     fn start_paragraph(&mut self) {
+        if self.in_footnote_definition {
+            return;
+        }
         // Insert an empty line between paragraphs if there is at least one line of text already.
         if self.needs_newline {
             self.push_line(Line::default());
@@ -642,6 +650,31 @@ where
         }
         self.needs_newline = true;
     }
+
+    fn footnote_reference(&mut self, label: CowStr<'a>) {
+        self.push_span(Span::styled(
+            format!("[{label}]"),
+            self.styles.footnote_ref(),
+        ));
+    }
+
+    fn start_footnote_definition(&mut self, label: CowStr<'a>) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        let style = self.styles.footnote_def();
+        self.push_line(Line::default());
+        self.push_span(Span::styled(format!("[{label}]: "), style));
+        self.line_styles.push(style);
+        self.in_footnote_definition = true;
+        self.needs_newline = false;
+    }
+
+    fn end_footnote_definition(&mut self) {
+        self.line_styles.pop();
+        self.in_footnote_definition = false;
+        self.needs_newline = true;
+    }
 }
 
 #[cfg(test)]
@@ -702,6 +735,31 @@ mod tests {
             "}),
             Text::from_iter(["Paragraph 1", "", "Paragraph 2",])
         );
+    }
+
+    mod footnotes {
+        use super::*;
+
+        #[rstest]
+        fn footnote_reference_renders(_with_tracing: DefaultGuard) {
+            let text = from_str("Text[^1]\n\n[^1]: The footnote content.");
+            let has_ref = text
+                .lines
+                .iter()
+                .any(|line| line.spans.iter().any(|span| span.content.contains("[1]")));
+            assert!(has_ref, "footnote reference should render as [1]");
+        }
+
+        #[rstest]
+        fn footnote_definition_renders(_with_tracing: DefaultGuard) {
+            let text = from_str("Text[^note]\n\n[^note]: A longer note.");
+            let has_definition = text.lines.iter().any(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.contains("[note]:"))
+            });
+            assert!(has_definition, "footnote definition should render");
+        }
     }
 
     #[rstest]

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -79,6 +79,8 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 /// - raw HTML: dim
 /// - inline math: magenta, italic
 /// - display math: magenta
+/// - footnote references: dim, italic
+/// - footnote definitions: dim
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DefaultStyleSheet;
 

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -51,6 +51,16 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
     fn math_display(&self) -> Style {
         Style::new().magenta()
     }
+
+    /// Style for footnote references (`[^label]`).
+    fn footnote_ref(&self) -> Style {
+        Style::new().dim().italic()
+    }
+
+    /// Style for footnote definitions.
+    fn footnote_def(&self) -> Style {
+        Style::new().dim()
+    }
 }
 
 /// The default style set


### PR DESCRIPTION
## Summary

Render footnote references and definitions, including multiple and multiline definitions. References render as `[label]`; definitions render as `[label]: content`.

## Example

```markdown
A statement with a note.[^source]

[^source]: Supporting detail.
```

References and definitions can be themed independently through `StyleSheet::footnote_ref()` and `StyleSheet::footnote_def()`.

## Documentation and tests

- Marks footnotes as supported and documents their visible output.
- Keeps blank separation between paragraphs in a definition.
- Composes reference styling with surrounding inline formatting.
- Covers multiple, multiline, multi-paragraph, nested, and custom-style cases with exact output assertions.

## Attribution

Originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125), with maintainer follow-up for paragraph structure and inline style composition.

## Validation

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, warning-denied documentation builds, and Markdown linting.
