### PR TITLE
feat(renderer): render definition lists

### DIFF
--- a/markdown-reader/README.md
+++ b/markdown-reader/README.md
@@ -56,6 +56,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Code blocks
 - [x] HTML
 - [x] Footnotes
+- [x] Definition lists
 - [ ] Tables
 - [x] Linebreak handling
 - [x] Rule

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -44,6 +44,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] HTML
 - [x] Math
 - [x] Footnotes
+- [x] Definition lists
 - [x] Linebreak handling
 - [x] Rule
 - [ ] Tables
@@ -71,6 +72,10 @@ separate terminal lines. Customize these styles with [`StyleSheet::math_inline()
 Footnote references such as `[^source]` are displayed as `[source]`, and definitions are displayed
 as `[source]: ...`. References are dim and italic by default, while definitions are dim. Customize
 these styles with [`StyleSheet::footnote_ref()`] and [`StyleSheet::footnote_def()`].
+
+Definition-list terms are bold by default, with each description rendered on its own line after a
+colon-and-space prefix. Customize them with [`StyleSheet::definition_term()`] and
+[`StyleSheet::definition_description()`].
 
 Metadata blocks are rendered using the metadata block style so front matter is visible, including
 the delimiter lines (for example `---` in YAML-style blocks).
@@ -134,6 +139,8 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md).
 [`StyleSheet::math_inline()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.math_inline
 [`StyleSheet::footnote_def()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.footnote_def
 [`StyleSheet::footnote_ref()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.footnote_ref
+[`StyleSheet::definition_description()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.definition_description
+[`StyleSheet::definition_term()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.definition_term
 
 [Crate badge]: https://img.shields.io/crates/v/tui-markdown?logo=rust&style=for-the-badge
 [Docs.rs Badge]: https://img.shields.io/docsrs/tui-markdown?logo=rust&style=for-the-badge

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -186,6 +186,9 @@ struct TextWriter<'a, I, S: StyleSheet> {
     /// Whether we are inside a footnote definition.
     in_footnote_definition: bool,
 
+    /// Whether we are inside a definition-list description.
+    in_definition_description: bool,
+
     needs_newline: bool,
 }
 
@@ -215,6 +218,7 @@ where
             heading_meta: None,
             in_metadata_block: false,
             in_footnote_definition: false,
+            in_definition_description: false,
         }
     }
 
@@ -306,16 +310,17 @@ where
     }
 
     fn start_paragraph(&mut self) {
-        // A footnote definition starts with a paragraph event after
-        // `start_footnote_definition` has already written `[label]: ` to the current line. Skip
-        // normal paragraph handling only for that first paragraph so its content stays beside the
-        // label. For a later paragraph, `needs_newline` is true; allowing the normal path below to
-        // run preserves the blank line in definitions such as:
+        // Footnote definitions and loose definition-list descriptions start with a paragraph event
+        // after their handlers have already written a visible prefix (`[label]: ` or `: `) to the
+        // current line. Skip normal paragraph handling only for that first paragraph so its content
+        // stays beside the prefix. For a later paragraph, `needs_newline` is true; allowing the
+        // normal path below to run preserves the blank line in definitions such as:
         //
         //     [^label]: First paragraph.
         //
         //         Second paragraph.
-        if self.in_footnote_definition && !self.needs_newline {
+        let prefix_line_is_open = self.in_footnote_definition || self.in_definition_description;
+        if prefix_line_is_open && !self.needs_newline {
             return;
         }
         // Insert an empty line between paragraphs if there is at least one line of text already.
@@ -720,11 +725,13 @@ where
         self.push_line(Line::default());
         self.push_span(Span::styled(": ", self.styles.definition_description()));
         self.push_inline_style(self.styles.definition_description());
+        self.in_definition_description = true;
         self.needs_newline = false;
     }
 
     fn end_definition_description(&mut self) {
         self.pop_inline_style();
+        self.in_definition_description = false;
         self.needs_newline = false;
     }
 }
@@ -1084,6 +1091,37 @@ mod tests {
                     Line::from(Span::styled("Term", Style::new().bold())),
                     Line::from_iter([Span::raw(": "), Span::raw("First description")]),
                     Line::from_iter([Span::raw(": "), Span::raw("Second description")]),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiple_description_paragraphs_keep_prefix_and_blank_line(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Term\n: First paragraph.\n\n  Second paragraph."),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", Style::new().bold())),
+                    Line::from_iter([Span::raw(": "), Span::raw("First paragraph.")]),
+                    Line::default(),
+                    Line::from("Second paragraph."),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn repeated_items_do_not_leak_into_following_paragraph(_with_tracing: DefaultGuard) {
+            let term_style = Style::new().bold();
+            assert_eq!(
+                from_str(
+                    "Term one\n: First description.\n\nTerm two\n: Second description.\n\nAfter."
+                ),
+                Text::from_iter([
+                    Line::from(Span::styled("Term one", term_style)),
+                    Line::from_iter([Span::raw(": "), Span::raw("First description.")]),
+                    Line::from(Span::styled("Term two", term_style)),
+                    Line::from_iter([Span::raw(": "), Span::raw("Second description.")]),
+                    Line::default(),
+                    Line::from("After."),
                 ])
             );
         }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -92,6 +92,7 @@ where
     parse_opts.insert(ParseOptions::ENABLE_SUBSCRIPT);
     parse_opts.insert(ParseOptions::ENABLE_MATH);
     parse_opts.insert(ParseOptions::ENABLE_FOOTNOTES);
+    parse_opts.insert(ParseOptions::ENABLE_DEFINITION_LIST);
     let parser = Parser::new_ext(input, parse_opts);
 
     let mut writer = TextWriter::new(parser, options.styles.clone());
@@ -270,9 +271,9 @@ where
             Tag::Link { dest_url, .. } => self.push_link(dest_url),
             Tag::Image { .. } => warn!("Image not yet supported"),
             Tag::MetadataBlock(_) => self.start_metadata_block(),
-            Tag::DefinitionList => warn!("Definition list not yet supported"),
-            Tag::DefinitionListTitle => warn!("Definition list title not yet supported"),
-            Tag::DefinitionListDefinition => warn!("Definition list definition not yet supported"),
+            Tag::DefinitionList => self.start_definition_list(),
+            Tag::DefinitionListTitle => self.start_definition_title(),
+            Tag::DefinitionListDefinition => self.start_definition_desc(),
         }
     }
 
@@ -298,9 +299,9 @@ where
             TagEnd::Link => self.pop_link(),
             TagEnd::Image => {}
             TagEnd::MetadataBlock(_) => self.end_metadata_block(),
-            TagEnd::DefinitionList => {}
-            TagEnd::DefinitionListTitle => {}
-            TagEnd::DefinitionListDefinition => {}
+            TagEnd::DefinitionList => self.end_definition_list(),
+            TagEnd::DefinitionListTitle => self.end_definition_title(),
+            TagEnd::DefinitionListDefinition => self.end_definition_desc(),
         }
     }
 
@@ -687,6 +688,40 @@ where
         self.in_footnote_definition = false;
         self.needs_newline = true;
     }
+
+    fn start_definition_list(&mut self) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+        }
+        self.needs_newline = false;
+    }
+
+    fn end_definition_list(&mut self) {
+        self.needs_newline = true;
+    }
+
+    fn start_definition_title(&mut self) {
+        self.push_line(Line::default());
+        self.push_inline_style(self.styles.definition_title());
+        self.needs_newline = false;
+    }
+
+    fn end_definition_title(&mut self) {
+        self.pop_inline_style();
+        self.needs_newline = false;
+    }
+
+    fn start_definition_desc(&mut self) {
+        self.push_line(Line::default());
+        self.push_span(Span::styled(": ", self.styles.definition_desc()));
+        self.push_inline_style(self.styles.definition_desc());
+        self.needs_newline = false;
+    }
+
+    fn end_definition_desc(&mut self) {
+        self.pop_inline_style();
+        self.needs_newline = false;
+    }
 }
 
 #[cfg(test)]
@@ -927,6 +962,55 @@ mod tests {
                     .style(definition_style),
                 ])
             );
+        }
+    }
+
+    mod definition_list {
+        use super::*;
+
+        #[rstest]
+        fn basic_definition_list(_with_tracing: DefaultGuard) {
+            let text = from_str(indoc! {"
+                Term 1
+                : Definition 1
+            "});
+            let has_term = text.lines.iter().any(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.contains("Term 1"))
+            });
+            assert!(has_term, "definition list should render the term");
+            let has_definition = text.lines.iter().any(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.contains("Definition 1"))
+            });
+            assert!(
+                has_definition,
+                "definition list should render the definition"
+            );
+        }
+
+        #[rstest]
+        fn definition_list_indentation(_with_tracing: DefaultGuard) {
+            let text = from_str(indoc! {"
+                Term
+                : Description here
+            "});
+            let definition_line = text
+                .lines
+                .iter()
+                .find(|line| {
+                    line.spans
+                        .iter()
+                        .any(|span| span.content.contains("Description"))
+                })
+                .expect("should have definition line");
+            let has_colon_prefix = definition_line
+                .spans
+                .iter()
+                .any(|span| span.content.contains(": "));
+            assert!(has_colon_prefix, "definition should have colon prefix");
         }
     }
 

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -273,7 +273,7 @@ where
             Tag::MetadataBlock(_) => self.start_metadata_block(),
             Tag::DefinitionList => self.start_definition_list(),
             Tag::DefinitionListTitle => self.start_definition_title(),
-            Tag::DefinitionListDefinition => self.start_definition_desc(),
+            Tag::DefinitionListDefinition => self.start_definition_description(),
         }
     }
 
@@ -301,7 +301,7 @@ where
             TagEnd::MetadataBlock(_) => self.end_metadata_block(),
             TagEnd::DefinitionList => self.end_definition_list(),
             TagEnd::DefinitionListTitle => self.end_definition_title(),
-            TagEnd::DefinitionListDefinition => self.end_definition_desc(),
+            TagEnd::DefinitionListDefinition => self.end_definition_description(),
         }
     }
 
@@ -701,8 +701,10 @@ where
     }
 
     fn start_definition_title(&mut self) {
+        // Definition-list terms contain inline events without an ordinary paragraph start, so the
+        // term handler owns the output line and applies the term style before consuming them.
         self.push_line(Line::default());
-        self.push_inline_style(self.styles.definition_title());
+        self.push_inline_style(self.styles.definition_term());
         self.needs_newline = false;
     }
 
@@ -711,14 +713,17 @@ where
         self.needs_newline = false;
     }
 
-    fn start_definition_desc(&mut self) {
+    fn start_definition_description(&mut self) {
+        // A tight description contains inline events without an ordinary paragraph start. Create
+        // its line here and write the visible Markdown `: ` marker before consuming the content so
+        // the marker and content share the description style.
         self.push_line(Line::default());
-        self.push_span(Span::styled(": ", self.styles.definition_desc()));
-        self.push_inline_style(self.styles.definition_desc());
+        self.push_span(Span::styled(": ", self.styles.definition_description()));
+        self.push_inline_style(self.styles.definition_description());
         self.needs_newline = false;
     }
 
-    fn end_definition_desc(&mut self) {
+    fn end_definition_description(&mut self) {
         self.pop_inline_style();
         self.needs_newline = false;
     }
@@ -998,58 +1003,13 @@ mod tests {
                 DefaultStyleSheet.metadata_block()
             }
 
-            fn definition_title(&self) -> Style {
+            fn definition_term(&self) -> Style {
                 Style::new().red().underlined()
             }
 
-            fn definition_desc(&self) -> Style {
+            fn definition_description(&self) -> Style {
                 Style::new().blue().italic()
             }
-        }
-
-        #[rstest]
-        fn basic_definition_list(_with_tracing: DefaultGuard) {
-            let text = from_str(indoc! {"
-                Term 1
-                : Definition 1
-            "});
-            let has_term = text.lines.iter().any(|line| {
-                line.spans
-                    .iter()
-                    .any(|span| span.content.contains("Term 1"))
-            });
-            assert!(has_term, "definition list should render the term");
-            let has_definition = text.lines.iter().any(|line| {
-                line.spans
-                    .iter()
-                    .any(|span| span.content.contains("Definition 1"))
-            });
-            assert!(
-                has_definition,
-                "definition list should render the definition"
-            );
-        }
-
-        #[rstest]
-        fn definition_list_indentation(_with_tracing: DefaultGuard) {
-            let text = from_str(indoc! {"
-                Term
-                : Description here
-            "});
-            let definition_line = text
-                .lines
-                .iter()
-                .find(|line| {
-                    line.spans
-                        .iter()
-                        .any(|span| span.content.contains("Description"))
-                })
-                .expect("should have definition line");
-            let has_colon_prefix = definition_line
-                .spans
-                .iter()
-                .any(|span| span.content.contains(": "));
-            assert!(has_colon_prefix, "definition should have colon prefix");
         }
 
         #[rstest]
@@ -1078,6 +1038,52 @@ mod tests {
                         Span::styled(": ", description_style),
                         Span::styled("Definition", description_style),
                     ]),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn inline_formatting_combines_with_definition_styles(_with_tracing: DefaultGuard) {
+            let options = Options::new(CustomDefinitionStyleSheet);
+            let term_style = Style::new().red().underlined().italic();
+            let description_style = Style::new().blue().italic();
+
+            assert_eq!(
+                from_str_with_options("*Term*\n: **Description**\n", &options),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", term_style)),
+                    Line::from_iter([
+                        Span::styled(": ", description_style),
+                        Span::styled("Description", description_style.bold()),
+                    ]),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiline_definition(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Term\n: First line\n  second line\n"),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", Style::new().bold())),
+                    Line::from_iter([
+                        Span::raw(": "),
+                        Span::raw("First line"),
+                        Span::raw(" "),
+                        Span::raw("second line"),
+                    ]),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn multiple_descriptions(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Term\n: First description\n: Second description\n"),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", Style::new().bold())),
+                    Line::from_iter([Span::raw(": "), Span::raw("First description")]),
+                    Line::from_iter([Span::raw(": "), Span::raw("Second description")]),
                 ])
             );
         }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -966,7 +966,46 @@ mod tests {
     }
 
     mod definition_list {
+        use pretty_assertions::assert_eq;
+
         use super::*;
+
+        #[derive(Clone)]
+        struct CustomDefinitionStyleSheet;
+
+        impl StyleSheet for CustomDefinitionStyleSheet {
+            fn heading(&self, level: u8) -> Style {
+                DefaultStyleSheet.heading(level)
+            }
+
+            fn code(&self) -> Style {
+                DefaultStyleSheet.code()
+            }
+
+            fn link(&self) -> Style {
+                DefaultStyleSheet.link()
+            }
+
+            fn blockquote(&self) -> Style {
+                DefaultStyleSheet.blockquote()
+            }
+
+            fn heading_meta(&self) -> Style {
+                DefaultStyleSheet.heading_meta()
+            }
+
+            fn metadata_block(&self) -> Style {
+                DefaultStyleSheet.metadata_block()
+            }
+
+            fn definition_title(&self) -> Style {
+                Style::new().red().underlined()
+            }
+
+            fn definition_desc(&self) -> Style {
+                Style::new().blue().italic()
+            }
+        }
 
         #[rstest]
         fn basic_definition_list(_with_tracing: DefaultGuard) {
@@ -1011,6 +1050,36 @@ mod tests {
                 .iter()
                 .any(|span| span.content.contains(": "));
             assert!(has_colon_prefix, "definition should have colon prefix");
+        }
+
+        #[rstest]
+        fn exact_output_and_default_styles(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Term\n: Definition\n"),
+                Text::from_iter([
+                    Line::from(Span::styled("Term", Style::new().bold())),
+                    Line::from_iter([Span::raw(": "), Span::raw("Definition")]),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn custom_styles_apply_to_terms_and_definitions(_with_tracing: DefaultGuard) {
+            let options = Options::new(CustomDefinitionStyleSheet);
+            let text = from_str_with_options("Term\n: Definition\n", &options);
+            let title_style = Style::new().red().underlined();
+            let description_style = Style::new().blue().italic();
+
+            assert_eq!(
+                text,
+                Text::from_iter([
+                    Line::from(Span::styled("Term", title_style)),
+                    Line::from_iter([
+                        Span::styled(": ", description_style),
+                        Span::styled("Definition", description_style),
+                    ]),
+                ])
+            );
         }
     }
 

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -61,6 +61,16 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
     fn footnote_def(&self) -> Style {
         Style::new().dim()
     }
+
+    /// Style for definition list terms.
+    fn definition_title(&self) -> Style {
+        Style::new().bold()
+    }
+
+    /// Style for definition list descriptions.
+    fn definition_desc(&self) -> Style {
+        Style::default()
+    }
 }
 
 /// The default style set

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -63,12 +63,12 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
     }
 
     /// Style for definition list terms.
-    fn definition_title(&self) -> Style {
+    fn definition_term(&self) -> Style {
         Style::new().bold()
     }
 
     /// Style for definition list descriptions.
-    fn definition_desc(&self) -> Style {
+    fn definition_description(&self) -> Style {
         Style::default()
     }
 }
@@ -91,6 +91,8 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 /// - display math: magenta
 /// - footnote references: dim, italic
 /// - footnote definitions: dim
+/// - definition list terms: bold
+/// - definition list descriptions: the surrounding style
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DefaultStyleSheet;
 


### PR DESCRIPTION
## Summary

Render Markdown definition lists with distinct term and description styling and a readable `: ` description prefix. Multiple descriptions and paragraphs retain their source structure.

## Example

```markdown
Ratatui
: A Rust library for building terminal user interfaces.
: Uses immediate-mode rendering.
```

Terms use `StyleSheet::definition_term()` and descriptions use `StyleSheet::definition_description()`.

## Documentation and tests

- Documents definition-list support in the library and reader.
- Uses caller-facing Markdown terminology for the public style hooks.
- Covers exact output, custom and nested inline styles, multiline and multi-paragraph descriptions, repeated items, and surrounding paragraphs.

## Attribution

Originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125), with maintainer API naming, contract coverage, and loose-description layout fixes.

## Validation

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, warning-denied documentation builds, and Markdown linting.
