### PR TITLE
feat(renderer): render GFM alerts

### DIFF
--- a/markdown-reader/README.md
+++ b/markdown-reader/README.md
@@ -48,6 +48,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Normal paragraphs
 - [x] Block quotes
 - [x] Nested block quotes
+- [x] GFM alerts
 - [x] Bold (strong)
 - [x] Italic (emphasis)
 - [x] Strikethrough

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -62,6 +62,11 @@ new line.
 Links are rendered as `label (URL)`. The link style applies to both the visible label and URL while
 preserving nested inline formatting such as bold text.
 
+GFM alerts render a bold icon and canonical English label above their quoted body. Customize each
+kind's color with [`StyleSheet::alert()`], its terminal-friendly icon with
+[`StyleSheet::alert_icon()`], and its label with [`StyleSheet::alert_label()`]. Returning an empty
+icon or label displays only the other component.
+
 Raw inline HTML tags and HTML blocks are displayed literally rather than interpreted as terminal
 markup. They are dimmed by default and can be customized with [`StyleSheet::html()`].
 
@@ -142,6 +147,9 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md).
 [`StyleSheet::footnote_ref()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.footnote_ref
 [`StyleSheet::definition_description()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.definition_description
 [`StyleSheet::definition_term()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.definition_term
+[`StyleSheet::alert()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.alert
+[`StyleSheet::alert_icon()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.alert_icon
+[`StyleSheet::alert_label()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.alert_label
 
 [Crate badge]: https://img.shields.io/crates/v/tui-markdown?logo=rust&style=for-the-badge
 [Docs.rs Badge]: https://img.shields.io/docsrs/tui-markdown?logo=rust&style=for-the-badge

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -35,6 +35,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Normal paragraphs
 - [x] Block quotes
 - [x] Nested block quotes
+- [x] GFM alerts
 - [x] Bold (strong)
 - [x] Italic (emphasis)
 - [x] Strikethrough

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -1186,53 +1186,31 @@ mod tests {
             }
         }
 
-        fn contains(text: &Text<'_>, expected: &str) -> bool {
-            text.lines.iter().any(|line| {
-                line.spans
-                    .iter()
-                    .any(|span| span.content.contains(expected))
-            })
-        }
-
         #[rstest]
-        fn note_alert(_with_tracing: DefaultGuard) {
-            let text = from_str("> [!NOTE]\n> This is a note.");
-            assert!(
-                contains(&text, "Note"),
-                "note alert should render Note label"
-            );
-        }
-
-        #[rstest]
-        fn tip_alert(_with_tracing: DefaultGuard) {
-            let text = from_str("> [!TIP]\n> A helpful tip.");
-            assert!(contains(&text, "Tip"), "tip alert should render Tip label");
-        }
-
-        #[rstest]
-        fn important_alert(_with_tracing: DefaultGuard) {
-            let text = from_str("> [!IMPORTANT]\n> Key information.");
-            assert!(
-                contains(&text, "Important"),
-                "important alert should render Important label"
-            );
-        }
-
-        #[rstest]
-        fn warning_alert(_with_tracing: DefaultGuard) {
-            let text = from_str("> [!WARNING]\n> Be careful!");
-            assert!(
-                contains(&text, "Warning"),
-                "warning alert should render Warning label"
-            );
-        }
-
-        #[rstest]
-        fn caution_alert(_with_tracing: DefaultGuard) {
-            let text = from_str("> [!CAUTION]\n> Risk of harm.");
-            assert!(
-                contains(&text, "Caution"),
-                "caution alert should render Caution label"
+        #[case("NOTE", "\u{2139}\u{FE0F} Note", Style::new().blue())]
+        #[case("TIP", "\u{1F4A1} Tip", Style::new().green())]
+        #[case("IMPORTANT", "\u{2757} Important", Style::new().magenta())]
+        #[case("WARNING", "\u{26A0}\u{FE0F} Warning", Style::new().yellow())]
+        #[case("CAUTION", "\u{1F534} Caution", Style::new().red())]
+        fn alert_kind_renders_exact_output(
+            _with_tracing: DefaultGuard,
+            #[case] marker: &str,
+            #[case] heading: &str,
+            #[case] style: Style,
+        ) {
+            let markdown = format!("> [!{marker}]\n> Body");
+            assert_eq!(
+                from_str(&markdown),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled(heading.to_owned(), style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
             );
         }
 
@@ -1274,6 +1252,33 @@ mod tests {
                     Line::from_iter([">", " ", "Parent"]).style(style),
                     Line::from_iter([">", " "]).style(style),
                     Line::from_iter([">", ">", " ", "Child"]).style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn alert_preserves_nested_blockquote(_with_tracing: DefaultGuard) {
+            let alert_style = Style::new().blue();
+            let blockquote_style = DefaultStyleSheet.blockquote();
+            assert_eq!(
+                from_str("> [!NOTE]\n> Parent\n>> Child"),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("\u{2139}\u{FE0F} Note", alert_style.bold()),
+                    ])
+                    .style(alert_style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Parent")])
+                        .style(alert_style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" ")]).style(alert_style),
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::raw("Child"),
+                    ])
+                    .style(blockquote_style),
                 ])
             );
         }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -93,6 +93,7 @@ where
     parse_opts.insert(ParseOptions::ENABLE_MATH);
     parse_opts.insert(ParseOptions::ENABLE_FOOTNOTES);
     parse_opts.insert(ParseOptions::ENABLE_DEFINITION_LIST);
+    parse_opts.insert(ParseOptions::ENABLE_GFM);
     let parser = Parser::new_ext(input, parse_opts);
 
     let mut writer = TextWriter::new(parser, options.styles.clone());
@@ -363,13 +364,31 @@ where
         self.needs_newline = true
     }
 
-    fn start_blockquote(&mut self, _kind: Option<BlockQuoteKind>) {
+    fn start_blockquote(&mut self, kind: Option<BlockQuoteKind>) {
         if self.needs_newline {
             self.push_line(Line::default());
             self.needs_newline = false;
         }
-        self.line_prefixes.push(Span::from(">"));
-        self.line_styles.push(self.styles.blockquote());
+
+        if let Some(alert_kind) = kind {
+            let (icon, kind_str) = match alert_kind {
+                BlockQuoteKind::Note => ("\u{2139}\u{FE0F}", "note"),
+                BlockQuoteKind::Tip => ("\u{1F4A1}", "tip"),
+                BlockQuoteKind::Important => ("\u{2757}", "important"),
+                BlockQuoteKind::Warning => ("\u{26A0}\u{FE0F}", "warning"),
+                BlockQuoteKind::Caution => ("\u{1F534}", "caution"),
+            };
+            let style = self.styles.alert(kind_str);
+            self.line_prefixes.push(Span::from(">"));
+            self.line_styles.push(style);
+            let label = kind_str[..1].to_uppercase() + &kind_str[1..];
+            self.push_line(Line::default());
+            self.push_span(Span::styled(format!("{icon} {label}"), style.bold()));
+            self.needs_newline = false;
+        } else {
+            self.line_prefixes.push(Span::from(">"));
+            self.line_styles.push(self.styles.blockquote());
+        }
     }
 
     fn end_blockquote(&mut self) {
@@ -1123,6 +1142,60 @@ mod tests {
                     Line::default(),
                     Line::from("After."),
                 ])
+            );
+        }
+    }
+
+    mod gfm_alerts {
+        use super::*;
+
+        fn contains(text: &Text<'_>, expected: &str) -> bool {
+            text.lines.iter().any(|line| {
+                line.spans
+                    .iter()
+                    .any(|span| span.content.contains(expected))
+            })
+        }
+
+        #[rstest]
+        fn note_alert(_with_tracing: DefaultGuard) {
+            let text = from_str("> [!NOTE]\n> This is a note.");
+            assert!(
+                contains(&text, "Note"),
+                "note alert should render Note label"
+            );
+        }
+
+        #[rstest]
+        fn tip_alert(_with_tracing: DefaultGuard) {
+            let text = from_str("> [!TIP]\n> A helpful tip.");
+            assert!(contains(&text, "Tip"), "tip alert should render Tip label");
+        }
+
+        #[rstest]
+        fn important_alert(_with_tracing: DefaultGuard) {
+            let text = from_str("> [!IMPORTANT]\n> Key information.");
+            assert!(
+                contains(&text, "Important"),
+                "important alert should render Important label"
+            );
+        }
+
+        #[rstest]
+        fn warning_alert(_with_tracing: DefaultGuard) {
+            let text = from_str("> [!WARNING]\n> Be careful!");
+            assert!(
+                contains(&text, "Warning"),
+                "warning alert should render Warning label"
+            );
+        }
+
+        #[rstest]
+        fn caution_alert(_with_tracing: DefaultGuard) {
+            let text = from_str("> [!CAUTION]\n> Risk of harm.");
+            assert!(
+                contains(&text, "Caution"),
+                "caution alert should render Caution label"
             );
         }
     }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -147,6 +147,16 @@ impl<'a> HeadingMeta<'a> {
     }
 }
 
+fn alert_kind(kind: BlockQuoteKind) -> AlertKind {
+    match kind {
+        BlockQuoteKind::Note => AlertKind::Note,
+        BlockQuoteKind::Tip => AlertKind::Tip,
+        BlockQuoteKind::Important => AlertKind::Important,
+        BlockQuoteKind::Warning => AlertKind::Warning,
+        BlockQuoteKind::Caution => AlertKind::Caution,
+    }
+}
+
 struct TextWriter<'a, I, S: StyleSheet> {
     /// Iterator supplying events.
     iter: I,
@@ -370,23 +380,38 @@ where
             self.needs_newline = false;
         }
 
-        if let Some(alert_kind) = kind {
-            let (kind, icon, label) = match alert_kind {
-                BlockQuoteKind::Note => (AlertKind::Note, "\u{2139}\u{FE0F}", "Note"),
-                BlockQuoteKind::Tip => (AlertKind::Tip, "\u{1F4A1}", "Tip"),
-                BlockQuoteKind::Important => (AlertKind::Important, "\u{2757}", "Important"),
-                BlockQuoteKind::Warning => (AlertKind::Warning, "\u{26A0}\u{FE0F}", "Warning"),
-                BlockQuoteKind::Caution => (AlertKind::Caution, "\u{1F534}", "Caution"),
-            };
-            let style = self.styles.alert(kind);
-            self.line_prefixes.push(Span::from(">"));
-            self.line_styles.push(style);
-            self.push_line(Line::default());
-            self.push_span(Span::styled(format!("{icon} {label}"), style.bold()));
-            self.needs_newline = false;
-        } else {
-            self.line_prefixes.push(Span::from(">"));
-            self.line_styles.push(self.styles.blockquote());
+        match kind {
+            Some(kind) => self.start_alert(alert_kind(kind)),
+            None => self.start_plain_blockquote(),
+        }
+    }
+
+    fn start_alert(&mut self, kind: AlertKind) {
+        let style = self.styles.alert(kind);
+        self.push_blockquote_style(style);
+        self.push_line(Line::default());
+        self.push_span(Span::styled(self.alert_heading(kind), style.bold()));
+        self.needs_newline = false;
+    }
+
+    fn start_plain_blockquote(&mut self) {
+        self.push_blockquote_style(self.styles.blockquote());
+    }
+
+    fn push_blockquote_style(&mut self, style: Style) {
+        self.line_prefixes.push(Span::from(">"));
+        self.line_styles.push(style);
+    }
+
+    fn alert_heading(&self, kind: AlertKind) -> String {
+        let icon = self.styles.alert_icon(kind);
+        let label = self.styles.alert_label(kind);
+        // Either component may be intentionally suppressed; add a separator only when both exist.
+        match (icon.is_empty(), label.is_empty()) {
+            (false, false) => format!("{icon} {label}"),
+            (false, true) => icon.to_owned(),
+            (true, false) => label.to_owned(),
+            (true, true) => String::new(),
         }
     }
 
@@ -1186,6 +1211,51 @@ mod tests {
             }
         }
 
+        #[derive(Clone)]
+        struct CustomAlertHeadingStyleSheet;
+
+        impl StyleSheet for CustomAlertHeadingStyleSheet {
+            fn heading(&self, level: u8) -> Style {
+                DefaultStyleSheet.heading(level)
+            }
+
+            fn code(&self) -> Style {
+                DefaultStyleSheet.code()
+            }
+
+            fn link(&self) -> Style {
+                DefaultStyleSheet.link()
+            }
+
+            fn blockquote(&self) -> Style {
+                DefaultStyleSheet.blockquote()
+            }
+
+            fn heading_meta(&self) -> Style {
+                DefaultStyleSheet.heading_meta()
+            }
+
+            fn metadata_block(&self) -> Style {
+                DefaultStyleSheet.metadata_block()
+            }
+
+            fn alert_icon(&self, kind: AlertKind) -> &str {
+                match kind {
+                    AlertKind::Note => "!!",
+                    AlertKind::Caution => "",
+                    _ => DefaultStyleSheet.alert_icon(kind),
+                }
+            }
+
+            fn alert_label(&self, kind: AlertKind) -> &str {
+                match kind {
+                    AlertKind::Tip => "Hint",
+                    AlertKind::Important => "",
+                    _ => kind.label(),
+                }
+            }
+        }
+
         #[rstest]
         #[case("NOTE", "\u{2139}\u{FE0F} Note", Style::new().blue())]
         #[case("TIP", "\u{1F4A1} Tip", Style::new().green())]
@@ -1226,6 +1296,86 @@ mod tests {
                         Span::raw(">"),
                         Span::raw(" "),
                         Span::styled("\u{2139}\u{FE0F} Note", style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn custom_alert_icon_replaces_default(_with_tracing: DefaultGuard) {
+            let style = DefaultStyleSheet.alert(AlertKind::Note);
+            let options = Options::new(CustomAlertHeadingStyleSheet);
+
+            assert_eq!(
+                from_str_with_options("> [!NOTE]\n> Body", &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("!! Note", style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn empty_alert_icon_suppresses_icon_and_separator(_with_tracing: DefaultGuard) {
+            let style = DefaultStyleSheet.alert(AlertKind::Caution);
+            let options = Options::new(CustomAlertHeadingStyleSheet);
+
+            assert_eq!(
+                from_str_with_options("> [!CAUTION]\n> Body", &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("Caution", style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn custom_alert_label_replaces_default(_with_tracing: DefaultGuard) {
+            let style = DefaultStyleSheet.alert(AlertKind::Tip);
+            let options = Options::new(CustomAlertHeadingStyleSheet);
+
+            assert_eq!(
+                from_str_with_options("> [!TIP]\n> Body", &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("💡 Hint", style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn empty_alert_label_suppresses_label_and_separator(_with_tracing: DefaultGuard) {
+            let style = DefaultStyleSheet.alert(AlertKind::Important);
+            let options = Options::new(CustomAlertHeadingStyleSheet);
+
+            assert_eq!(
+                from_str_with_options("> [!IMPORTANT]\n> Body", &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("❗", style.bold()),
                     ])
                     .style(style),
                     Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -53,7 +53,7 @@ use syntect::{
 use tracing::{debug, instrument, warn};
 
 pub use crate::options::Options;
-pub use crate::style_sheet::{DefaultStyleSheet, StyleSheet};
+pub use crate::style_sheet::{AlertKind, DefaultStyleSheet, StyleSheet};
 
 mod options;
 mod style_sheet;
@@ -371,17 +371,16 @@ where
         }
 
         if let Some(alert_kind) = kind {
-            let (icon, kind_str) = match alert_kind {
-                BlockQuoteKind::Note => ("\u{2139}\u{FE0F}", "note"),
-                BlockQuoteKind::Tip => ("\u{1F4A1}", "tip"),
-                BlockQuoteKind::Important => ("\u{2757}", "important"),
-                BlockQuoteKind::Warning => ("\u{26A0}\u{FE0F}", "warning"),
-                BlockQuoteKind::Caution => ("\u{1F534}", "caution"),
+            let (kind, icon, label) = match alert_kind {
+                BlockQuoteKind::Note => (AlertKind::Note, "\u{2139}\u{FE0F}", "Note"),
+                BlockQuoteKind::Tip => (AlertKind::Tip, "\u{1F4A1}", "Tip"),
+                BlockQuoteKind::Important => (AlertKind::Important, "\u{2757}", "Important"),
+                BlockQuoteKind::Warning => (AlertKind::Warning, "\u{26A0}\u{FE0F}", "Warning"),
+                BlockQuoteKind::Caution => (AlertKind::Caution, "\u{1F534}", "Caution"),
             };
-            let style = self.styles.alert(kind_str);
+            let style = self.styles.alert(kind);
             self.line_prefixes.push(Span::from(">"));
             self.line_styles.push(style);
-            let label = kind_str[..1].to_uppercase() + &kind_str[1..];
             self.push_line(Line::default());
             self.push_span(Span::styled(format!("{icon} {label}"), style.bold()));
             self.needs_newline = false;
@@ -1147,7 +1146,45 @@ mod tests {
     }
 
     mod gfm_alerts {
+        use pretty_assertions::assert_eq;
+
         use super::*;
+
+        #[derive(Clone)]
+        struct CustomAlertStyleSheet;
+
+        impl StyleSheet for CustomAlertStyleSheet {
+            fn heading(&self, level: u8) -> Style {
+                DefaultStyleSheet.heading(level)
+            }
+
+            fn code(&self) -> Style {
+                DefaultStyleSheet.code()
+            }
+
+            fn link(&self) -> Style {
+                DefaultStyleSheet.link()
+            }
+
+            fn blockquote(&self) -> Style {
+                DefaultStyleSheet.blockquote()
+            }
+
+            fn heading_meta(&self) -> Style {
+                DefaultStyleSheet.heading_meta()
+            }
+
+            fn metadata_block(&self) -> Style {
+                DefaultStyleSheet.metadata_block()
+            }
+
+            fn alert(&self, kind: AlertKind) -> Style {
+                match kind {
+                    AlertKind::Note => Style::new().on_red(),
+                    _ => Style::default(),
+                }
+            }
+        }
 
         fn contains(text: &Text<'_>, expected: &str) -> bool {
             text.lines.iter().any(|line| {
@@ -1196,6 +1233,48 @@ mod tests {
             assert!(
                 contains(&text, "Caution"),
                 "caution alert should render Caution label"
+            );
+        }
+
+        #[rstest]
+        fn custom_alert_style_applies_to_header_and_body(_with_tracing: DefaultGuard) {
+            let style = Style::new().on_red();
+            let options = Options::new(CustomAlertStyleSheet);
+
+            assert_eq!(
+                from_str_with_options("> [!NOTE]\n> Body", &options),
+                Text::from_iter([
+                    Line::from_iter([
+                        Span::raw(">"),
+                        Span::raw(" "),
+                        Span::styled("\u{2139}\u{FE0F} Note", style.bold()),
+                    ])
+                    .style(style),
+                    Line::from_iter([Span::raw(">"), Span::raw(" "), Span::raw("Body")])
+                        .style(style),
+                ])
+            );
+        }
+
+        #[rstest]
+        fn ordinary_blockquote_keeps_standard_prefix(_with_tracing: DefaultGuard) {
+            let style = DefaultStyleSheet.blockquote();
+            assert_eq!(
+                from_str("> Ordinary"),
+                Text::from(Line::from_iter([">", " ", "Ordinary"]).style(style))
+            );
+        }
+
+        #[rstest]
+        fn nested_blockquote_keeps_each_standard_prefix(_with_tracing: DefaultGuard) {
+            let style = DefaultStyleSheet.blockquote();
+            assert_eq!(
+                from_str("> Parent\n>> Child"),
+                Text::from_iter([
+                    Line::from_iter([">", " ", "Parent"]).style(style),
+                    Line::from_iter([">", " "]).style(style),
+                    Line::from_iter([">", ">", " ", "Child"]).style(style),
+                ])
             );
         }
     }

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -2,8 +2,7 @@
 //!
 //! The library used to hard–code all color and attribute choices in an internal `styles` module.
 //! That made it impossible for downstream crates to provide their own look-and-feel. The
-//! [`StyleSheet`] trait makes it possible to customize the styles used to display the
-//! [`ratatui_core::style::Style`] values the renderer needs.
+//! [`StyleSheet`] trait makes it possible to customize the styles and symbols the renderer uses.
 //!
 //! Users that are happy with the stock colors do not have to do anything – the crate exports a
 //! [`DefaultStyleSheet`] which matches the old behaviour and is used by default. Projects that want
@@ -27,11 +26,23 @@ pub enum AlertKind {
     Caution,
 }
 
-/// A collection of `ratatui_core::style::Style`s consumed by the renderer.
+impl AlertKind {
+    /// The canonical English label for this alert kind.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Note => "Note",
+            Self::Tip => "Tip",
+            Self::Important => "Important",
+            Self::Warning => "Warning",
+            Self::Caution => "Caution",
+        }
+    }
+}
+
+/// Visual styles and symbols consumed by the renderer.
 ///
-/// The trait purposefully stays tiny: whenever the renderer needs a color choice we add a new
-/// getter here. The default implementation maintains full backward-compatibility with the styles
-/// that lived in the old `mod styles`.
+/// The trait purposefully stays tiny: whenever the renderer needs a presentation choice we add a
+/// new getter here. The default implementation maintains the renderer's standard appearance.
 pub trait StyleSheet: Clone + Send + Sync + 'static {
     /// Style for a Markdown heading.
     ///
@@ -100,6 +111,26 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
             AlertKind::Warning => Style::new().fg(Color::Yellow),
             AlertKind::Caution => Style::new().fg(Color::Red),
         }
+    }
+
+    /// Icon displayed before a GFM alert label.
+    ///
+    /// Return an empty string to render the label without an icon.
+    fn alert_icon(&self, kind: AlertKind) -> &str {
+        match kind {
+            AlertKind::Note => "\u{2139}\u{FE0F}",
+            AlertKind::Tip => "\u{1F4A1}",
+            AlertKind::Important => "\u{2757}",
+            AlertKind::Warning => "\u{26A0}\u{FE0F}",
+            AlertKind::Caution => "\u{1F534}",
+        }
+    }
+
+    /// Label displayed after a GFM alert icon.
+    ///
+    /// Return an empty string to render the icon without a label.
+    fn alert_label(&self, kind: AlertKind) -> &str {
+        kind.label()
     }
 }
 

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -12,6 +12,21 @@
 
 use ratatui_core::style::Style;
 
+/// The kind of a GitHub Flavored Markdown alert.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum AlertKind {
+    /// Supplementary information.
+    Note,
+    /// Helpful advice.
+    Tip,
+    /// Information essential to success.
+    Important,
+    /// Urgent information that needs attention.
+    Warning,
+    /// A risk or negative outcome.
+    Caution,
+}
+
 /// A collection of `ratatui_core::style::Style`s consumed by the renderer.
 ///
 /// The trait purposefully stays tiny: whenever the renderer needs a color choice we add a new
@@ -74,17 +89,15 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 
     /// Style for a GFM alert/callout blockquote.
     ///
-    /// `kind` is one of `"note"`, `"tip"`, `"important"`, `"warning"`, or `"caution"`.
-    fn alert(&self, kind: &str) -> Style {
+    fn alert(&self, kind: AlertKind) -> Style {
         use ratatui_core::style::Color;
 
         match kind {
-            "note" => Style::new().fg(Color::Blue),
-            "tip" => Style::new().fg(Color::Green),
-            "important" => Style::new().fg(Color::Magenta),
-            "warning" => Style::new().fg(Color::Yellow),
-            "caution" => Style::new().fg(Color::Red),
-            _ => Style::default(),
+            AlertKind::Note => Style::new().fg(Color::Blue),
+            AlertKind::Tip => Style::new().fg(Color::Green),
+            AlertKind::Important => Style::new().fg(Color::Magenta),
+            AlertKind::Warning => Style::new().fg(Color::Yellow),
+            AlertKind::Caution => Style::new().fg(Color::Red),
         }
     }
 }

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -87,8 +87,9 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
         Style::default()
     }
 
-    /// Style for a GFM alert/callout blockquote.
+    /// Style for a GFM alert heading and body.
     ///
+    /// The generated icon and label are bold in addition to this base style.
     fn alert(&self, kind: AlertKind) -> Style {
         use ratatui_core::style::Color;
 
@@ -122,6 +123,11 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 /// - footnote definitions: dim
 /// - definition list terms: bold
 /// - definition list descriptions: the surrounding style
+/// - note alerts: blue
+/// - tip alerts: green
+/// - important alerts: magenta
+/// - warning alerts: yellow
+/// - caution alerts: red
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DefaultStyleSheet;
 

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -71,6 +71,22 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
     fn definition_description(&self) -> Style {
         Style::default()
     }
+
+    /// Style for a GFM alert/callout blockquote.
+    ///
+    /// `kind` is one of `"note"`, `"tip"`, `"important"`, `"warning"`, or `"caution"`.
+    fn alert(&self, kind: &str) -> Style {
+        use ratatui_core::style::Color;
+
+        match kind {
+            "note" => Style::new().fg(Color::Blue),
+            "tip" => Style::new().fg(Color::Green),
+            "important" => Style::new().fg(Color::Magenta),
+            "warning" => Style::new().fg(Color::Yellow),
+            "caution" => Style::new().fg(Color::Red),
+            _ => Style::default(),
+        }
+    }
 }
 
 /// The default style set


### PR DESCRIPTION
## Summary

Render GitHub-flavored Markdown alerts for notes, tips, important information, warnings, and cautions with customizable labels and icons plus distinct default colors.

## Example

```markdown
> [!WARNING]
> Back up your data before continuing.
```

This renders a yellow alert with a bold `⚠️ Warning` heading followed by the quoted body. Applications can customize each kind's style through `StyleSheet::alert(AlertKind)`, choose terminal-appropriate icons through `StyleSheet::alert_icon(AlertKind)`, and localize or replace labels through `StyleSheet::alert_label(AlertKind)`.

For example, a style sheet can replace emoji with ASCII, suppress an icon by returning an empty string, and rename a label:

```rust
fn alert_icon(&self, kind: AlertKind) -> &str {
    match kind {
        AlertKind::Warning => "!!",
        AlertKind::Caution => "",
        _ => "i",
    }
}

fn alert_label(&self, kind: AlertKind) -> &str {
    match kind {
        AlertKind::Warning => "Heads up",
        _ => kind.label(),
    }
}
```

## Documentation and tests

- Documents GFM alert support, the default palette, and icon customization.
- Exposes the typed `AlertKind::{Note, Tip, Important, Warning, Caution}` API.
- Keeps ordinary blockquotes using `>`.
- Verifies exact output and styling for all five kinds, custom and empty icons and labels, ordinary blockquotes, and nested alert content.

## Attribution

Originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125), with maintainer follow-up for the typed API, customizable alert headings, focused rendering helpers, and exact nesting contracts.

## Validation

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, warning-denied documentation builds, and Markdown linting.
