### PR TITLE
feat(renderer): render image fallbacks

### DIFF
--- a/markdown-reader/README.md
+++ b/markdown-reader/README.md
@@ -63,7 +63,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Rule
 - [x] Tasklists
 - [x] Links
-- [ ] Images
+- [x] Images
 - [x] Metadata blocks
 - [x] Superscript
 - [x] Subscript

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -51,13 +51,17 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Tables
 - [x] Tasklists
 - [x] Links
-- [ ] Images
+- [x] Images
 - [x] Metadata blocks
 - [x] Superscript
 - [x] Subscript
 
 Linebreaks are rendered with Markdown defaults: soft breaks become spaces, hard breaks insert a
 new line.
+
+Images render as text fallbacks rather than terminal graphics. The default output uses `[img]`
+followed by the image description, or the destination when the description is empty. For example,
+`Before ![diagram](diagram.png) after` renders as `Before [img] diagram after`.
 
 GFM tables render with Unicode box-drawing borders and honor left, center, and right column
 alignment:

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -7,6 +7,10 @@
 //! GitHub-flavored Markdown tables render with Unicode box-drawing borders, terminal-width-aware
 //! columns, and the alignment declared by the Markdown delimiter row. Use [`StyleSheet`] to
 //! customize header cells, body cells, and borders.
+//!
+//! Images render as `[img]` followed by their description, or by their destination when the
+//! description is empty. This is a text fallback; the crate does not load or render image
+//! resources.
 #![cfg_attr(feature = "document-features", doc = "\n# Features")]
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 //! # Example
@@ -68,7 +72,8 @@ const IMAGE_INDICATOR: &str = "[img]";
 /// Render Markdown `input` into a [`Text`] using the default [`Options`].
 ///
 /// This is a convenience function that uses the default options, which are defined in
-/// [`Options::default`]. It is suitable for most use cases where you want to render Markdown
+/// [`Options::default`]. Image syntax renders as a styled text fallback so its description or
+/// destination remains visible in terminals without image graphics.
 pub fn from_str(input: &str) -> Text<'_> {
     from_str_with_options(input, &Options::default())
 }
@@ -187,6 +192,51 @@ struct ListItemLayout {
     continuation_width: usize,
 }
 
+/// An image whose description is still being emitted by pulldown-cmark.
+///
+/// Image descriptions arrive as the same inline event stream used for ordinary text: formatting,
+/// code, HTML, math, and even nested images are separate events between the image's start and end.
+/// Buffer the rendered spans until the end event so the fallback marker stays at the correct image
+/// boundary and the destination is used only when the description produced no content. A stack is
+/// required because pulldown-cmark can emit nested image events inside a description.
+#[derive(Debug)]
+struct PendingImage<'a> {
+    destination: CowStr<'a>,
+    style: Style,
+    description: Vec<Span<'a>>,
+}
+
+impl<'a> PendingImage<'a> {
+    fn new(destination: CowStr<'a>, style: Style) -> Self {
+        Self {
+            destination,
+            style,
+            description: Vec::new(),
+        }
+    }
+
+    fn push_span(&mut self, span: Span<'a>) {
+        self.description.push(span);
+    }
+
+    fn into_fallback(self) -> Vec<Span<'a>> {
+        let mut content = self.description;
+        if content.is_empty() && !self.destination.is_empty() {
+            content.push(Span::styled(self.destination, self.style));
+        }
+
+        let indicator = if content.is_empty() {
+            IMAGE_INDICATOR.to_owned()
+        } else {
+            format!("{IMAGE_INDICATOR} ")
+        };
+        let mut fallback = Vec::with_capacity(content.len() + 1);
+        fallback.push(Span::styled(indicator, self.style));
+        fallback.extend(content);
+        fallback
+    }
+}
+
 struct TextWriter<'a, I, S: StyleSheet> {
     /// Iterator supplying events.
     iter: I,
@@ -218,11 +268,8 @@ struct TextWriter<'a, I, S: StyleSheet> {
     /// A link which will be appended to the current line when the link tag is closed.
     link: Option<CowStr<'a>>,
 
-    /// Image destination URL stored between image start and end events.
-    image_url: Option<CowStr<'a>>,
-
-    /// Whether any alt text was rendered for the current image.
-    image_had_alt: bool,
+    /// Images whose descriptions are currently being collected.
+    images: Vec<PendingImage<'a>>,
 
     /// The [`StyleSheet`] to use to style the output.
     styles: S,
@@ -268,8 +315,7 @@ where
             #[cfg(feature = "highlight-code")]
             code_highlighter: None,
             link: None,
-            image_url: None,
-            image_had_alt: false,
+            images: vec![],
             styles,
             heading_meta: None,
             in_metadata_block: false,
@@ -468,10 +514,6 @@ where
     }
 
     fn text(&mut self, text: CowStr<'a>) {
-        if self.image_url.is_some() {
-            self.image_had_alt = true;
-        }
-
         if self.table_builder.is_some() {
             let style = self.inline_styles.last().copied().unwrap_or_default();
             self.push_span(Span::styled(text, style));
@@ -512,12 +554,23 @@ where
     }
 
     fn code(&mut self, code: CowStr<'a>) {
-        let span = Span::styled(code, self.styles.code());
+        let style = if self.images.is_empty() {
+            self.styles.code()
+        } else {
+            let inline_style = self.inline_styles.last().copied().unwrap_or_default();
+            inline_style.patch(self.styles.code())
+        };
+
+        let span = Span::styled(code, style);
         self.push_span(span);
     }
 
     fn hard_break(&mut self) {
-        self.push_line(Line::default());
+        if self.images.is_empty() {
+            self.push_line(Line::default());
+        } else {
+            self.image_description_break();
+        }
     }
 
     fn start_metadata_block(&mut self) {
@@ -611,9 +664,18 @@ where
     fn soft_break(&mut self) {
         if self.in_metadata_block {
             self.hard_break();
-        } else {
+        } else if self.images.is_empty() {
             self.push_span(Span::raw(" "));
+        } else {
+            self.image_description_break();
         }
+    }
+
+    fn image_description_break(&mut self) {
+        // Image descriptions are inline content. Keep a break readable without allowing it to
+        // split the surrounding document, and retain the image style in case it has a background.
+        let style = self.inline_styles.last().copied().unwrap_or_default();
+        self.push_span(Span::styled(" ", style));
     }
 
     fn start_codeblock(&mut self, kind: CodeBlockKind<'_>) {
@@ -700,6 +762,13 @@ where
 
     #[instrument(level = "trace", skip(self))]
     fn push_span(&mut self, span: Span<'a>) {
+        // An active image owns every span produced by its inline event stream. Checking it before
+        // the table sink also lets a completed fallback enter a table cell as one ordered unit.
+        if let Some(image) = self.images.last_mut() {
+            image.push_span(span);
+            return;
+        }
+
         // GFM tables are leaf blocks: their cells parse inline content, and block-level elements
         // cannot occur inside them. Pulldown-cmark preserves that boundary by emitting only inline
         // events inside `TableCell`. Keep the active cell as the single span sink anyway so a new
@@ -735,34 +804,26 @@ where
         }
     }
 
-    /// Store the image URL and style its alt text.
+    /// Begin collecting the rendered image description.
     #[instrument(level = "trace", skip(self))]
     fn start_image(&mut self, dest_url: CowStr<'a>) {
-        self.image_url = Some(dest_url);
-        self.image_had_alt = false;
         self.push_inline_style(self.styles.image_alt());
+        let style = self.inline_styles.last().copied().unwrap_or_default();
+        self.images.push(PendingImage::new(dest_url, style));
     }
 
-    /// Render an image as styled alt text, falling back to its URL when the alt text is empty.
+    /// Finish the current image and emit its text fallback to the enclosing output.
+    ///
+    /// Pop the image before emitting so a nested image becomes part of its parent's description,
+    /// while an outer image continues through the usual table or document span sink.
     #[instrument(level = "trace", skip(self))]
     fn end_image(&mut self) {
         self.pop_inline_style();
-        if let Some(url) = self.image_url.take() {
-            let style = self.styles.image_alt();
-            let prefix = format!("{IMAGE_INDICATOR} ");
-            if self.image_had_alt {
-                if let Some(line) = self.text.lines.last_mut() {
-                    if let Some(span) = line.spans.iter_mut().find(|span| span.style == style) {
-                        span.content.to_mut().insert_str(0, &prefix);
-                    } else {
-                        line.spans.push(Span::styled(prefix, style));
-                    }
-                }
-            } else {
-                self.push_span(Span::styled(format!("{prefix}{url}"), style));
+        if let Some(image) = self.images.pop() {
+            for span in image.into_fallback() {
+                self.push_span(span);
             }
         }
-        self.image_had_alt = false;
     }
 
     fn start_html_block(&mut self) {
@@ -2188,11 +2249,47 @@ mod tests {
 
         const IMAGE_STYLE: Style = Style::new().dim().italic();
 
+        #[derive(Clone)]
+        struct UnstyledImageStyleSheet;
+
+        impl StyleSheet for UnstyledImageStyleSheet {
+            fn heading(&self, _level: u8) -> Style {
+                Style::default()
+            }
+
+            fn code(&self) -> Style {
+                Style::default()
+            }
+
+            fn link(&self) -> Style {
+                Style::default()
+            }
+
+            fn blockquote(&self) -> Style {
+                Style::default()
+            }
+
+            fn heading_meta(&self) -> Style {
+                Style::default()
+            }
+
+            fn metadata_block(&self) -> Style {
+                Style::default()
+            }
+
+            fn image_alt(&self) -> Style {
+                Style::default()
+            }
+        }
+
         #[rstest]
         fn image_with_alt(_with_tracing: DefaultGuard) {
             assert_eq!(
                 from_str("![Alt text](https://example.com/image.png)"),
-                Text::from(Line::from(Span::styled("[img] Alt text", IMAGE_STYLE)))
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("Alt text", IMAGE_STYLE),
+                ]))
             );
         }
 
@@ -2200,10 +2297,10 @@ mod tests {
         fn image_without_alt(_with_tracing: DefaultGuard) {
             assert_eq!(
                 from_str("![](https://example.com/image.png)"),
-                Text::from(Line::from(Span::styled(
-                    "[img] https://example.com/image.png",
-                    IMAGE_STYLE,
-                )))
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("https://example.com/image.png", IMAGE_STYLE),
+                ]))
             );
         }
 
@@ -2211,7 +2308,10 @@ mod tests {
         fn image_with_title(_with_tracing: DefaultGuard) {
             assert_eq!(
                 from_str("![Alt](https://example.com/img.png \"My Title\")"),
-                Text::from(Line::from(Span::styled("[img] Alt", IMAGE_STYLE)))
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("Alt", IMAGE_STYLE),
+                ]))
             );
         }
 
@@ -2221,8 +2321,187 @@ mod tests {
                 from_str("Before ![photo](url.png) after"),
                 Text::from(Line::from_iter([
                     Span::from("Before "),
-                    Span::styled("[img] photo", IMAGE_STYLE),
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("photo", IMAGE_STYLE),
                     Span::from(" after"),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn multiple_images_in_paragraph(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![first](first.png) and ![second](second.png)").to_string(),
+                "[img] first and [img] second"
+            );
+        }
+
+        #[rstest]
+        fn formatted_alt_text_keeps_prefix_before_content(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![**bold**](image.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("bold", IMAGE_STYLE.bold()),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn inline_code_counts_as_alt_text(_with_tracing: DefaultGuard) {
+            let code_style = IMAGE_STYLE.patch(DefaultStyleSheet.code());
+            assert_eq!(
+                from_str("![`code`](image.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("code", code_style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn marker_and_alt_compose_with_enclosing_style(_with_tracing: DefaultGuard) {
+            let style = IMAGE_STYLE.bold();
+            assert_eq!(
+                from_str("**![diagram](diagram.png)**"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", style),
+                    Span::styled("diagram", style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn marker_and_url_compose_with_enclosing_style(_with_tracing: DefaultGuard) {
+            let style = IMAGE_STYLE.bold();
+            assert_eq!(
+                from_str("**![](diagram.png)**"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", style),
+                    Span::styled("diagram.png", style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn inline_math_counts_as_alt_text(_with_tracing: DefaultGuard) {
+            let math_style = IMAGE_STYLE.magenta();
+            assert_eq!(
+                from_str("![$x$](equation.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("$x$", math_style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn inline_html_counts_as_alt_text(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![<br>](break.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("<br>", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn nested_image_description_preserves_order_and_style(_with_tracing: DefaultGuard) {
+            let code_style = IMAGE_STYLE.patch(DefaultStyleSheet.code());
+            assert_eq!(
+                from_str("![outer ![inner](inner.png) `code`](outer.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("outer ", IMAGE_STYLE),
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("inner", IMAGE_STYLE),
+                    Span::styled(" ", IMAGE_STYLE),
+                    Span::styled("code", code_style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn empty_description_and_destination_omit_trailing_space(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Before ![]() after"),
+                Text::from(Line::from_iter([
+                    Span::raw("Before "),
+                    Span::styled("[img]", IMAGE_STYLE),
+                    Span::raw(" after"),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn multiline_description_renders_as_styled_inline_text(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                ![first line
+                second line](image.png)
+            "};
+            assert_eq!(
+                from_str(markdown),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("first line", IMAGE_STYLE),
+                    Span::styled(" ", IMAGE_STYLE),
+                    Span::styled("second line", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn hard_break_in_description_stays_inline(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                ![first line  
+                second line](image.png)
+            "};
+            assert_eq!(
+                from_str(markdown),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("first line", IMAGE_STYLE),
+                    Span::styled(" ", IMAGE_STYLE),
+                    Span::styled("second line", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn image_fallback_stays_inside_table_cell(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                | Image |
+                |-------|
+                | ![photo](photo.png) |
+            "};
+            let rendered = from_str(markdown)
+                .lines
+                .iter()
+                .map(ToString::to_string)
+                .collect_vec();
+            assert_eq!(
+                rendered,
+                [
+                    "┌─────────────┐",
+                    "│ Image       │",
+                    "├─────────────┤",
+                    "│ [img] photo │",
+                    "└─────────────┘",
+                ]
+            );
+        }
+
+        #[rstest]
+        fn unstyled_fallback_does_not_modify_surrounding_text(_with_tracing: DefaultGuard) {
+            let options = Options::new(UnstyledImageStyleSheet);
+            assert_eq!(
+                from_str_with_options("Before ![photo](photo.png) after", &options),
+                Text::from(Line::from_iter([
+                    Span::raw("Before "),
+                    Span::raw("[img] "),
+                    Span::raw("photo"),
+                    Span::raw(" after"),
                 ]))
             );
         }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -1178,10 +1178,6 @@ mod tests {
                     DefaultStyleSheet.metadata_block()
                 }
 
-                fn image_alt(&self) -> Style {
-                    DefaultStyleSheet.image_alt()
-                }
-
                 fn footnote_ref(&self) -> Style {
                     Style::new().red().underlined()
                 }
@@ -1243,10 +1239,6 @@ mod tests {
 
             fn metadata_block(&self) -> Style {
                 DefaultStyleSheet.metadata_block()
-            }
-
-            fn image_alt(&self) -> Style {
-                DefaultStyleSheet.image_alt()
             }
 
             fn definition_term(&self) -> Style {
@@ -1399,10 +1391,6 @@ mod tests {
                 DefaultStyleSheet.metadata_block()
             }
 
-            fn image_alt(&self) -> Style {
-                DefaultStyleSheet.image_alt()
-            }
-
             fn alert(&self, kind: AlertKind) -> Style {
                 match kind {
                     AlertKind::Note => Style::new().on_red(),
@@ -1437,10 +1425,6 @@ mod tests {
 
             fn metadata_block(&self) -> Style {
                 DefaultStyleSheet.metadata_block()
-            }
-
-            fn image_alt(&self) -> Style {
-                DefaultStyleSheet.image_alt()
             }
 
             fn alert_icon(&self, kind: AlertKind) -> &str {
@@ -2176,10 +2160,6 @@ mod tests {
 
                 fn metadata_block(&self) -> Style {
                     DefaultStyleSheet.metadata_block()
-                }
-
-                fn image_alt(&self) -> Style {
-                    DefaultStyleSheet.image_alt()
                 }
 
                 fn math_display(&self) -> Style {

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -63,6 +63,8 @@ mod options;
 mod style_sheet;
 mod tables;
 
+const IMAGE_INDICATOR: &str = "[img]";
+
 /// Render Markdown `input` into a [`Text`] using the default [`Options`].
 ///
 /// This is a convenience function that uses the default options, which are defined in
@@ -216,6 +218,12 @@ struct TextWriter<'a, I, S: StyleSheet> {
     /// A link which will be appended to the current line when the link tag is closed.
     link: Option<CowStr<'a>>,
 
+    /// Image destination URL stored between image start and end events.
+    image_url: Option<CowStr<'a>>,
+
+    /// Whether any alt text was rendered for the current image.
+    image_had_alt: bool,
+
     /// The [`StyleSheet`] to use to style the output.
     styles: S,
 
@@ -260,6 +268,8 @@ where
             #[cfg(feature = "highlight-code")]
             code_highlighter: None,
             link: None,
+            image_url: None,
+            image_had_alt: false,
             styles,
             heading_meta: None,
             in_metadata_block: false,
@@ -320,7 +330,7 @@ where
             Tag::Subscript => self.push_inline_style(Style::new().dim().italic()),
             Tag::Superscript => self.push_inline_style(Style::new().dim().italic()),
             Tag::Link { dest_url, .. } => self.push_link(dest_url),
-            Tag::Image { .. } => warn!("Image not yet supported"),
+            Tag::Image { dest_url, .. } => self.start_image(dest_url),
             Tag::MetadataBlock(_) => self.start_metadata_block(),
             Tag::DefinitionList => self.start_definition_list(),
             Tag::DefinitionListTitle => self.start_definition_title(),
@@ -348,7 +358,7 @@ where
             TagEnd::Subscript => self.pop_inline_style(),
             TagEnd::Superscript => self.pop_inline_style(),
             TagEnd::Link => self.pop_link(),
-            TagEnd::Image => {}
+            TagEnd::Image => self.end_image(),
             TagEnd::MetadataBlock(_) => self.end_metadata_block(),
             TagEnd::DefinitionList => self.end_definition_list(),
             TagEnd::DefinitionListTitle => self.end_definition_title(),
@@ -458,6 +468,10 @@ where
     }
 
     fn text(&mut self, text: CowStr<'a>) {
+        if self.image_url.is_some() {
+            self.image_had_alt = true;
+        }
+
         if self.table_builder.is_some() {
             let style = self.inline_styles.last().copied().unwrap_or_default();
             self.push_span(Span::styled(text, style));
@@ -720,6 +734,37 @@ where
             self.push_span(")".into());
         }
     }
+
+    /// Store the image URL and style its alt text.
+    #[instrument(level = "trace", skip(self))]
+    fn start_image(&mut self, dest_url: CowStr<'a>) {
+        self.image_url = Some(dest_url);
+        self.image_had_alt = false;
+        self.push_inline_style(self.styles.image_alt());
+    }
+
+    /// Render an image as styled alt text, falling back to its URL when the alt text is empty.
+    #[instrument(level = "trace", skip(self))]
+    fn end_image(&mut self) {
+        self.pop_inline_style();
+        if let Some(url) = self.image_url.take() {
+            let style = self.styles.image_alt();
+            let prefix = format!("{IMAGE_INDICATOR} ");
+            if self.image_had_alt {
+                if let Some(line) = self.text.lines.last_mut() {
+                    if let Some(span) = line.spans.iter_mut().find(|span| span.style == style) {
+                        span.content.to_mut().insert_str(0, &prefix);
+                    } else {
+                        line.spans.push(Span::styled(prefix, style));
+                    }
+                }
+            } else {
+                self.push_span(Span::styled(format!("{prefix}{url}"), style));
+            }
+        }
+        self.image_had_alt = false;
+    }
+
     fn start_html_block(&mut self) {
         if self.needs_newline {
             self.push_line(Line::default());
@@ -1133,6 +1178,10 @@ mod tests {
                     DefaultStyleSheet.metadata_block()
                 }
 
+                fn image_alt(&self) -> Style {
+                    DefaultStyleSheet.image_alt()
+                }
+
                 fn footnote_ref(&self) -> Style {
                     Style::new().red().underlined()
                 }
@@ -1194,6 +1243,10 @@ mod tests {
 
             fn metadata_block(&self) -> Style {
                 DefaultStyleSheet.metadata_block()
+            }
+
+            fn image_alt(&self) -> Style {
+                DefaultStyleSheet.image_alt()
             }
 
             fn definition_term(&self) -> Style {
@@ -1346,6 +1399,10 @@ mod tests {
                 DefaultStyleSheet.metadata_block()
             }
 
+            fn image_alt(&self) -> Style {
+                DefaultStyleSheet.image_alt()
+            }
+
             fn alert(&self, kind: AlertKind) -> Style {
                 match kind {
                     AlertKind::Note => Style::new().on_red(),
@@ -1380,6 +1437,10 @@ mod tests {
 
             fn metadata_block(&self) -> Style {
                 DefaultStyleSheet.metadata_block()
+            }
+
+            fn image_alt(&self) -> Style {
+                DefaultStyleSheet.image_alt()
             }
 
             fn alert_icon(&self, kind: AlertKind) -> &str {
@@ -2117,6 +2178,10 @@ mod tests {
                     DefaultStyleSheet.metadata_block()
                 }
 
+                fn image_alt(&self) -> Style {
+                    DefaultStyleSheet.image_alt()
+                }
+
                 fn math_display(&self) -> Style {
                     Style::new().red().bold()
                 }
@@ -2132,6 +2197,53 @@ mod tests {
                     Line::from(Span::styled("y = z", style)),
                     Line::from(Span::styled("$$", style)),
                 ])
+            );
+        }
+    }
+
+    mod image {
+        use pretty_assertions::assert_eq;
+
+        use super::*;
+
+        const IMAGE_STYLE: Style = Style::new().dim().italic();
+
+        #[rstest]
+        fn image_with_alt(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![Alt text](https://example.com/image.png)"),
+                Text::from(Line::from(Span::styled("[img] Alt text", IMAGE_STYLE)))
+            );
+        }
+
+        #[rstest]
+        fn image_without_alt(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![](https://example.com/image.png)"),
+                Text::from(Line::from(Span::styled(
+                    "[img] https://example.com/image.png",
+                    IMAGE_STYLE,
+                )))
+            );
+        }
+
+        #[rstest]
+        fn image_with_title(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![Alt](https://example.com/img.png \"My Title\")"),
+                Text::from(Line::from(Span::styled("[img] Alt", IMAGE_STYLE)))
+            );
+        }
+
+        #[rstest]
+        fn image_in_paragraph(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Before ![photo](url.png) after"),
+                Text::from(Line::from_iter([
+                    Span::from("Before "),
+                    Span::styled("[img] photo", IMAGE_STYLE),
+                    Span::from(" after"),
+                ]))
             );
         }
     }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -49,6 +49,10 @@ use crate::{DefaultStyleSheet, StyleSheet};
 ///     fn metadata_block(&self) -> Style {
 ///         Style::new().light_yellow()
 ///     }
+///
+///     fn image_alt(&self) -> Style {
+///         Style::new().dim().italic()
+///     }
 /// }
 ///
 /// let options = Options::new(MyStyleSheet);
@@ -121,6 +125,10 @@ mod tests {
             fn metadata_block(&self) -> Style {
                 Style::new().light_yellow()
             }
+
+            fn image_alt(&self) -> Style {
+                Style::new().dim().italic()
+            }
         }
 
         let options = Options {
@@ -134,5 +142,6 @@ mod tests {
         assert_eq!(options.styles.blockquote(), Style::new().yellow());
         assert_eq!(options.styles.heading_meta(), Style::new().dim());
         assert_eq!(options.styles.metadata_block(), Style::new().light_yellow());
+        assert_eq!(options.styles.image_alt(), Style::new().dim().italic());
     }
 }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -50,9 +50,6 @@ use crate::{DefaultStyleSheet, StyleSheet};
 ///         Style::new().light_yellow()
 ///     }
 ///
-///     fn image_alt(&self) -> Style {
-///         Style::new().dim().italic()
-///     }
 /// }
 ///
 /// let options = Options::new(MyStyleSheet);
@@ -124,10 +121,6 @@ mod tests {
 
             fn metadata_block(&self) -> Style {
                 Style::new().light_yellow()
-            }
-
-            fn image_alt(&self) -> Style {
-                Style::new().dim().italic()
             }
         }
 

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -156,7 +156,9 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
     }
 
     /// Style for the alt-text fallback when rendering images.
-    fn image_alt(&self) -> Style;
+    fn image_alt(&self) -> Style {
+        Style::new().dim().italic()
+    }
 }
 
 /// The default style set
@@ -221,9 +223,5 @@ impl StyleSheet for DefaultStyleSheet {
 
     fn metadata_block(&self) -> Style {
         Style::new().light_yellow()
-    }
-
-    fn image_alt(&self) -> Style {
-        Style::new().dim().italic()
     }
 }

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -154,6 +154,9 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
     fn table_border(&self) -> Style {
         Style::new().dark_gray()
     }
+
+    /// Style for the alt-text fallback when rendering images.
+    fn image_alt(&self) -> Style;
 }
 
 /// The default style set
@@ -218,5 +221,9 @@ impl StyleSheet for DefaultStyleSheet {
 
     fn metadata_block(&self) -> Style {
         Style::new().light_yellow()
+    }
+
+    fn image_alt(&self) -> Style {
+        Style::new().dim().italic()
     }
 }

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -155,7 +155,9 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
         Style::new().dark_gray()
     }
 
-    /// Style for the alt-text fallback when rendering images.
+    /// Style for the marker and text used to represent Markdown images.
+    ///
+    /// The default is dim and italic. The renderer patches this over any enclosing inline style.
     fn image_alt(&self) -> Style {
         Style::new().dim().italic()
     }
@@ -189,6 +191,7 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 /// - table headers: bold cyan
 /// - table cells: the surrounding style
 /// - table borders: dark gray
+/// - image fallback text: dim and italic
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DefaultStyleSheet;
 

--- a/tui-markdown/src/tables/tests.rs
+++ b/tui-markdown/src/tables/tests.rs
@@ -195,10 +195,6 @@ impl StyleSheet for CustomTableStyleSheet {
         Style::default()
     }
 
-    fn image_alt(&self) -> Style {
-        Style::default()
-    }
-
     fn table_header(&self) -> Style {
         Style::new().on_blue()
     }

--- a/tui-markdown/src/tables/tests.rs
+++ b/tui-markdown/src/tables/tests.rs
@@ -195,6 +195,10 @@ impl StyleSheet for CustomTableStyleSheet {
         Style::default()
     }
 
+    fn image_alt(&self) -> Style {
+        Style::default()
+    }
+
     fn table_header(&self) -> Style {
         Style::new().on_blue()
     }


### PR DESCRIPTION
## Summary

Render Markdown images as readable text fallbacks so image content remains meaningful in terminals without image rendering support.

## Example

```rust
use tui_markdown::from_str;

assert_eq!(
    from_str("Before ![diagram](diagram.png) after").to_string(),
    "Before [img] diagram after",
);
assert_eq!(from_str("![](diagram.png)").to_string(), "[img] diagram.png");
```

This PR intentionally renders text only; it does not load or render image resources. The default uses the image description and falls back to the destination when the description is empty. `StyleSheet::image_alt()` styles the marker and fallback content.

## Design

Pulldown-cmark emits an image description as an inline event stream rather than one string. The renderer buffers those spans in a `PendingImage` stack until the matching image end event. This preserves formatted descriptions, code, math, HTML, nested images, surrounding styles, and exact ordering while keeping fallbacks inside table cells. Capturing the complete description separately also leaves a clean boundary for future structured or terminal image renderers.

## Documentation and tests

- Documents the text-only behavior in crate docs, Rustdoc, and the README.
- Covers empty descriptions and destinations without trailing whitespace.
- Covers soft and hard multiline descriptions with exact styles.
- Covers formatted text, code, math, HTML, nested images, surrounding styles, multiple images, custom unstyled fallbacks, and images in GFM tables.
- Gives `StyleSheet::image_alt()` a default so existing custom style sheets remain source-compatible.

## Attribution

Originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125), with maintainer compatibility and image-boundary fixes.

## Validation

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, warning-denied documentation builds, doctests, and Markdown linting.
