### PR TITLE
feat(options): configure image fallbacks

### DIFF
--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -63,6 +63,16 @@ Images render as text fallbacks rather than terminal graphics. The default outpu
 followed by the image description, or the destination when the description is empty. For example,
 `Before ![diagram](diagram.png) after` renders as `Before [img] diagram after`.
 
+Use [`ImageFallback`] to show the destination instead, or to include it after the description:
+
+```rust
+use tui_markdown::{from_str_with_options, ImageFallback, Options};
+
+let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+let text = from_str_with_options("![diagram](diagram.png)", &options);
+assert_eq!(text.to_string(), "[img] diagram (diagram.png)");
+```
+
 GFM tables render with Unicode box-drawing borders and honor left, center, and right column
 alignment:
 
@@ -179,6 +189,7 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md).
 [`StyleSheet::table_border()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.table_border
 [`StyleSheet::table_cell()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.table_cell
 [`StyleSheet::table_header()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.table_header
+[`ImageFallback`]: https://docs.rs/tui-markdown/latest/tui_markdown/enum.ImageFallback.html
 
 [Crate badge]: https://img.shields.io/crates/v/tui-markdown?logo=rust&style=for-the-badge
 [Docs.rs Badge]: https://img.shields.io/docsrs/tui-markdown?logo=rust&style=for-the-badge

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -60,7 +60,7 @@ use syntect::{
 };
 use tracing::{debug, instrument, warn};
 
-pub use crate::options::Options;
+pub use crate::options::{ImageFallback, Options};
 pub use crate::style_sheet::{AlertKind, DefaultStyleSheet, StyleSheet};
 
 mod options;
@@ -109,7 +109,7 @@ where
     parse_opts.insert(ParseOptions::ENABLE_TABLES);
     let parser = Parser::new_ext(input, parse_opts);
 
-    let mut writer = TextWriter::new(parser, options.styles.clone());
+    let mut writer = TextWriter::new(parser, options.styles.clone(), options.image_fallback);
     writer.run();
     writer.text
 }
@@ -219,21 +219,45 @@ impl<'a> PendingImage<'a> {
         self.description.push(span);
     }
 
-    fn into_fallback(self) -> Vec<Span<'a>> {
-        let mut content = self.description;
-        if content.is_empty() && !self.destination.is_empty() {
-            content.push(Span::styled(self.destination, self.style));
-        }
+    fn into_fallback(self, fallback: ImageFallback) -> Vec<Span<'a>> {
+        let Self {
+            destination,
+            style,
+            description,
+        } = self;
+        let mut content = match fallback {
+            ImageFallback::AltText if description.is_empty() => {
+                Self::destination_span(destination, style)
+            }
+            ImageFallback::AltText => description,
+            ImageFallback::Url => Self::destination_span(destination, style),
+            ImageFallback::AltTextAndUrl if description.is_empty() => {
+                Self::destination_span(destination, style)
+            }
+            ImageFallback::AltTextAndUrl if destination.is_empty() => description,
+            ImageFallback::AltTextAndUrl => {
+                let mut description = description;
+                let destination = format!(" ({destination})");
+                description.push(Span::styled(destination, style));
+                description
+            }
+        };
 
         let indicator = if content.is_empty() {
             IMAGE_INDICATOR.to_owned()
         } else {
             format!("{IMAGE_INDICATOR} ")
         };
-        let mut fallback = Vec::with_capacity(content.len() + 1);
-        fallback.push(Span::styled(indicator, self.style));
-        fallback.extend(content);
-        fallback
+        content.insert(0, Span::styled(indicator, style));
+        content
+    }
+
+    fn destination_span(destination: CowStr<'a>, style: Style) -> Vec<Span<'a>> {
+        if destination.is_empty() {
+            Vec::new()
+        } else {
+            vec![Span::styled(destination, style)]
+        }
     }
 }
 
@@ -271,6 +295,9 @@ struct TextWriter<'a, I, S: StyleSheet> {
     /// Images whose descriptions are currently being collected.
     images: Vec<PendingImage<'a>>,
 
+    /// Content to render in place of images.
+    image_fallback: ImageFallback,
+
     /// The [`StyleSheet`] to use to style the output.
     styles: S,
 
@@ -302,7 +329,7 @@ where
     I: Iterator<Item = Event<'a>>,
     S: StyleSheet,
 {
-    fn new(iter: I, styles: S) -> Self {
+    fn new(iter: I, styles: S, image_fallback: ImageFallback) -> Self {
         Self {
             iter,
             text: Text::default(),
@@ -316,6 +343,7 @@ where
             code_highlighter: None,
             link: None,
             images: vec![],
+            image_fallback,
             styles,
             heading_meta: None,
             in_metadata_block: false,
@@ -820,7 +848,7 @@ where
     fn end_image(&mut self) {
         self.pop_inline_style();
         if let Some(image) = self.images.pop() {
-            for span in image.into_fallback() {
+            for span in image.into_fallback(self.image_fallback) {
                 self.push_span(span);
             }
         }
@@ -2489,6 +2517,64 @@ mod tests {
                     "│ [img] photo │",
                     "└─────────────┘",
                 ]
+            );
+        }
+
+        #[rstest]
+        fn url_fallback_uses_destination(_with_tracing: DefaultGuard) {
+            let options = Options::default().image_fallback(ImageFallback::Url);
+            assert_eq!(
+                from_str_with_options("![diagram](diagram.png)", &options),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("diagram.png", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn url_fallback_discards_complete_formatted_description(_with_tracing: DefaultGuard) {
+            let options = Options::default().image_fallback(ImageFallback::Url);
+            assert_eq!(
+                from_str_with_options("![**bold** $x$ <br> `code`](diagram.png)", &options)
+                    .to_string(),
+                "[img] diagram.png"
+            );
+        }
+
+        #[rstest]
+        fn alt_text_and_url_fallback_preserves_formatted_description(_with_tracing: DefaultGuard) {
+            let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+            assert_eq!(
+                from_str_with_options("![**diagram**](diagram.png)", &options),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("diagram", IMAGE_STYLE.bold()),
+                    Span::styled(" (diagram.png)", IMAGE_STYLE),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn alt_text_and_url_fallback_uses_destination_for_empty_description(
+            _with_tracing: DefaultGuard,
+        ) {
+            let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+            assert_eq!(
+                from_str_with_options("![](diagram.png)", &options).to_string(),
+                "[img] diagram.png"
+            );
+        }
+
+        #[rstest]
+        fn configured_fallback_omits_space_when_destination_is_empty(
+            #[values(ImageFallback::Url, ImageFallback::AltTextAndUrl)] fallback: ImageFallback,
+            _with_tracing: DefaultGuard,
+        ) {
+            let options = Options::default().image_fallback(fallback);
+            assert_eq!(
+                from_str_with_options("![]()", &options),
+                Text::from(Line::from(Span::styled("[img]", IMAGE_STYLE)))
             );
         }
 

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -1,21 +1,38 @@
 //! Rendering configuration for tui-markdown.
 //!
-//! Options control the renderer's style sheet and image fallback content. This struct is
-//! `#[non_exhaustive]`, which allows us to add more options in the future without breaking
-//! existing code.
+//! Options control the renderer's style sheet and image fallback content. [`Options`] is
+//! non-exhaustive, allowing new rendering choices to be added without breaking existing code.
 
 use crate::{DefaultStyleSheet, StyleSheet};
 
-/// Text used in place of images when rendering Markdown in a terminal.
+/// Text used to represent Markdown images in rendered terminal output.
+///
+/// This option does not load or render image resources. It controls whether the text fallback
+/// contains the image description, destination, or both. [`AltText`](Self::AltText) is the
+/// default.
+///
+/// # Example
+///
+/// ```
+/// use tui_markdown::{from_str_with_options, ImageFallback, Options};
+///
+/// let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+/// let text = from_str_with_options("![Architecture diagram](diagram.png)", &options);
+///
+/// assert_eq!(
+///     text.to_string(),
+///     "[img] Architecture diagram (diagram.png)"
+/// );
+/// ```
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ImageFallback {
-    /// Show the image's alt text, or its URL when the alt text is empty.
+    /// Show `[img]` followed by the description, or the destination when the description is empty.
     #[default]
     AltText,
-    /// Always show the image's URL.
+    /// Show `[img]` followed by the destination, ignoring the description.
     Url,
-    /// Show both the image's alt text and URL, or only its URL when the alt text is empty.
+    /// Show `[img] {description} ({destination})`, omitting either value when it is empty.
     AltTextAndUrl,
 }
 
@@ -28,7 +45,7 @@ pub enum ImageFallback {
 /// # Example
 ///
 /// ```
-/// use tui_markdown::{DefaultStyleSheet, Options};
+/// use tui_markdown::Options;
 /// let options = Options::default();
 ///
 /// // or with a custom style sheet
@@ -40,7 +57,7 @@ pub enum ImageFallback {
 /// struct MyStyleSheet;
 ///
 /// impl StyleSheet for MyStyleSheet {
-///     fn heading(&self, level: u8) -> Style {
+///     fn heading(&self, _level: u8) -> Style {
 ///         Style::new().bold()
 ///     }
 ///
@@ -63,7 +80,6 @@ pub enum ImageFallback {
 ///     fn metadata_block(&self) -> Style {
 ///         Style::new().light_yellow()
 ///     }
-///
 /// }
 ///
 /// let options = Options::new(MyStyleSheet);
@@ -87,7 +103,9 @@ impl<S: StyleSheet> Options<S> {
         }
     }
 
-    /// Selects the content to render in place of images.
+    /// Selects the text used to represent Markdown images.
+    ///
+    /// See [`ImageFallback`] for the exact output of each mode.
     #[must_use]
     pub fn image_fallback(mut self, image_fallback: ImageFallback) -> Self {
         self.image_fallback = image_fallback;

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -1,9 +1,23 @@
 //! Rendering configuration for tui-markdown.
 //!
-//! For now the only knob is the theme [`StyleSheet`]. This struct is `#[non_exhaustive]`, which
-//! allows us to add more options in the future without breaking existing code.
+//! Options control the renderer's style sheet and image fallback content. This struct is
+//! `#[non_exhaustive]`, which allows us to add more options in the future without breaking
+//! existing code.
 
 use crate::{DefaultStyleSheet, StyleSheet};
+
+/// Text used in place of images when rendering Markdown in a terminal.
+#[non_exhaustive]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ImageFallback {
+    /// Show the image's alt text, or its URL when the alt text is empty.
+    #[default]
+    AltText,
+    /// Always show the image's URL.
+    Url,
+    /// Show both the image's alt text and URL, or only its URL when the alt text is empty.
+    AltTextAndUrl,
+}
 
 /// Collection of optional parameters that influence markdown rendering.
 ///
@@ -60,12 +74,24 @@ pub struct Options<S: StyleSheet = DefaultStyleSheet> {
     /// The [`StyleSheet`] implementation that will be consulted every time the renderer needs a
     /// color choice.
     pub(crate) styles: S,
+    /// The content to render in place of images.
+    pub(crate) image_fallback: ImageFallback,
 }
 
 impl<S: StyleSheet> Options<S> {
     /// Creates a new `Options` instance with the provided style sheet.
     pub fn new(styles: S) -> Self {
-        Self { styles }
+        Self {
+            styles,
+            image_fallback: ImageFallback::default(),
+        }
+    }
+
+    /// Selects the content to render in place of images.
+    #[must_use]
+    pub fn image_fallback(mut self, image_fallback: ImageFallback) -> Self {
+        self.image_fallback = image_fallback;
+        self
     }
 }
 
@@ -126,6 +152,7 @@ mod tests {
 
         let options = Options {
             styles: CustomStyleSheet,
+            image_fallback: ImageFallback::default(),
         };
 
         assert_eq!(options.styles.heading(1), Style::new().red().bold());
@@ -136,5 +163,19 @@ mod tests {
         assert_eq!(options.styles.heading_meta(), Style::new().dim());
         assert_eq!(options.styles.metadata_block(), Style::new().light_yellow());
         assert_eq!(options.styles.image_alt(), Style::new().dim().italic());
+    }
+
+    #[test]
+    fn image_fallback_defaults_to_alt_text() {
+        let options = Options::default();
+
+        assert_eq!(options.image_fallback, ImageFallback::AltText);
+    }
+
+    #[test]
+    fn image_fallback_setter_updates_mode() {
+        let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+
+        assert_eq!(options.image_fallback, ImageFallback::AltTextAndUrl);
     }
 }


### PR DESCRIPTION
## Summary

Allow callers to choose whether Markdown image text fallbacks show the description, destination, or both through the new non-exhaustive `ImageFallback` option.

## Example

```rust
use tui_markdown::{from_str_with_options, ImageFallback, Options};

let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
let text = from_str_with_options(
    "![Architecture diagram](diagram.png)",
    &options,
);
assert_eq!(text.to_string(), "[img] Architecture diagram (diagram.png)");
```

The modes produce:

- `AltText`: `[img] description`, falling back to the destination when the description is empty.
- `Url`: `[img] destination`.
- `AltTextAndUrl`: `[img] description (destination)`, omitting empty pieces cleanly.

`AltText` remains the default. The enum is non-exhaustive so additional policies can be added without making the existing public API needlessly rigid. This option controls text output only; it does not load or render image resources.

## Design

Fallback policy is applied after [#155](https://github.com/joshka/tui-markdown/pull/155) captures the complete image description. URL-only output therefore discards the entire formatted description—including code, math, and HTML—rather than suppressing selected parser events. That separation keeps parsing independent from presentation policy and leaves room for future structured or terminal image rendering.

## Documentation and tests

- Documents each mode, its default, exact output, and the text-only scope in Rustdoc and the README.
- Includes a compiling public API example.
- Covers every mode, empty descriptions and destinations, punctuation and spacing boundaries, formatted descriptions, and complete suppression under URL-only mode.

## Attribution

This configuration API is a maintainer follow-up to the image support originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125).

## Validation

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, warning-denied documentation builds, doctests, and Markdown linting.
