### PR TITLE
feat(renderer): expose structured image blocks

### DIFF
--- a/markdown-reader/README.md
+++ b/markdown-reader/README.md
@@ -61,7 +61,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Rule
 - [x] Tasklists
 - [ ] Links
-- [ ] Images
+- [x] Images
 - [x] Metadata blocks
 - [x] Superscript
 - [x] Subscript

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -48,7 +48,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [ ] Tables
 - [x] Tasklists
 - [ ] Links
-- [ ] Images
+- [x] Images
 - [x] Metadata blocks
 - [x] Superscript
 - [x] Subscript

--- a/tui-markdown/src/content.rs
+++ b/tui-markdown/src/content.rs
@@ -5,7 +5,11 @@
 
 use ratatui_core::text::Text;
 
-/// A single renderable block within a parsed Markdown document.
+/// A single renderable segment within a parsed Markdown document.
+///
+/// Inline images split their surrounding text into ordered [`Text`](Self::Text),
+/// [`Image`](Self::Image), and [`Text`](Self::Text) segments. These values are output segments, not
+/// a representation of Markdown's block-level syntax.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MarkdownBlock<'a> {
     /// Regular text content such as headings, paragraphs, lists, and code blocks.
@@ -21,10 +25,10 @@ pub enum MarkdownBlock<'a> {
     },
 }
 
-/// An ordered sequence of renderable Markdown blocks.
+/// An ordered sequence of renderable Markdown segments.
 ///
 /// Returned by [`crate::parse`] and [`crate::parse_with_options`]. Images are represented as
-/// separate blocks rather than being flattened to alt text.
+/// separate segments rather than being flattened to alt text.
 ///
 /// # Example
 ///

--- a/tui-markdown/src/content.rs
+++ b/tui-markdown/src/content.rs
@@ -1,0 +1,50 @@
+//! Structured Markdown content with separate text and image blocks.
+//!
+//! [`MarkdownContent`] is returned by [`crate::parse`] and preserves images as distinct blocks
+//! that consumers can render with their own image handling.
+
+use ratatui_core::text::Text;
+
+/// A single renderable block within a parsed Markdown document.
+#[derive(Debug, Clone)]
+pub enum MarkdownBlock<'a> {
+    /// Regular text content such as headings, paragraphs, lists, and code blocks.
+    Text(Text<'a>),
+    /// An image that can be rendered separately from surrounding text.
+    Image {
+        /// The image URL or file path.
+        url: String,
+        /// The image alt text, or an empty string when none was provided.
+        alt: String,
+        /// The optional title from the Markdown image syntax.
+        title: Option<String>,
+    },
+}
+
+/// An ordered sequence of renderable Markdown blocks.
+///
+/// Returned by [`crate::parse`] and [`crate::parse_with_options`]. Images are represented as
+/// separate blocks rather than being flattened to alt text.
+///
+/// # Example
+///
+/// ```
+/// use tui_markdown::{parse, MarkdownBlock};
+///
+/// let content = parse("Hello\n\n![photo](pic.png)\n\nWorld");
+/// for block in &content.blocks {
+///     match block {
+///         MarkdownBlock::Text(text) => {
+///             // Render text normally with Ratatui.
+///         }
+///         MarkdownBlock::Image { url, alt, .. } => {
+///             // Render the image with custom image handling.
+///         }
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct MarkdownContent<'a> {
+    /// The ordered sequence of blocks in this document.
+    pub blocks: Vec<MarkdownBlock<'a>>,
+}

--- a/tui-markdown/src/content.rs
+++ b/tui-markdown/src/content.rs
@@ -6,7 +6,7 @@
 use ratatui_core::text::Text;
 
 /// A single renderable block within a parsed Markdown document.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MarkdownBlock<'a> {
     /// Regular text content such as headings, paragraphs, lists, and code blocks.
     Text(Text<'a>),
@@ -43,7 +43,7 @@ pub enum MarkdownBlock<'a> {
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MarkdownContent<'a> {
     /// The ordered sequence of blocks in this document.
     pub blocks: Vec<MarkdownBlock<'a>>,

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -103,8 +103,29 @@ where
 
 /// Parse Markdown `input` into structured content using the default [`Options`].
 ///
-/// Unlike [`from_str`], images are represented as separate [`MarkdownBlock::Image`] blocks rather
+/// Unlike [`from_str`], images are represented as separate [`MarkdownBlock::Image`] segments rather
 /// than being flattened to alt text. This allows consumers to provide custom image rendering.
+/// Inline images split their surrounding text into ordered text, image, and text segments.
+///
+/// # Example
+///
+/// ```
+/// use tui_markdown::{parse, MarkdownBlock};
+///
+/// let content = parse("Before ![diagram](diagram.png \"Architecture\") after");
+/// for block in content.blocks {
+///     match block {
+///         MarkdownBlock::Text(text) => {
+///             // Render `text` with Ratatui.
+///         }
+///         MarkdownBlock::Image { url, alt, title } => {
+///             assert_eq!(url, "diagram.png");
+///             assert_eq!(alt, "diagram");
+///             assert_eq!(title.as_deref(), Some("Architecture"));
+///         }
+///     }
+/// }
+/// ```
 pub fn parse(input: &str) -> MarkdownContent<'_> {
     parse_with_options(input, &Options::default())
 }
@@ -325,6 +346,16 @@ where
 
     #[instrument(level = "debug", skip(self))]
     fn handle_event(&mut self, event: Event<'a>) {
+        if self.collecting_image_alt {
+            match event {
+                Event::End(TagEnd::Image) => self.end_image(),
+                Event::Text(text) | Event::Code(text) => self.image_alt_buffer.push_str(&text),
+                Event::SoftBreak | Event::HardBreak => self.image_alt_buffer.push(' '),
+                _ => {}
+            }
+            return;
+        }
+
         match event {
             Event::Start(tag) => self.start_tag(tag),
             Event::End(tag) => self.end_tag(tag),
@@ -462,11 +493,6 @@ where
     }
 
     fn text(&mut self, text: CowStr<'a>) {
-        if self.collecting_image_alt {
-            self.image_alt_buffer.push_str(&text);
-            return;
-        }
-
         if self.image_url.is_some() {
             self.image_had_alt = true;
         }
@@ -1405,6 +1431,48 @@ mod tests {
                             url: "pic.png".to_string(),
                             alt: "photo".to_string(),
                             title: Some("A photo".to_string()),
+                        },
+                        MarkdownBlock::Text(Text::from(" after")),
+                    ],
+                }
+            );
+        }
+
+        #[rstest]
+        fn parse_collects_formatted_image_description_without_leaking_text(
+            _with_tracing: DefaultGuard,
+        ) {
+            let content = parse("Before ![an *important* `diagram`](pic.png) after");
+
+            assert_eq!(
+                content,
+                MarkdownContent {
+                    blocks: vec![
+                        MarkdownBlock::Text(Text::from("Before ")),
+                        MarkdownBlock::Image {
+                            url: "pic.png".to_string(),
+                            alt: "an important diagram".to_string(),
+                            title: None,
+                        },
+                        MarkdownBlock::Text(Text::from(" after")),
+                    ],
+                }
+            );
+        }
+
+        #[rstest]
+        fn parse_normalizes_breaks_in_image_description(_with_tracing: DefaultGuard) {
+            let content = parse("Before ![first line\nsecond line](pic.png) after");
+
+            assert_eq!(
+                content,
+                MarkdownContent {
+                    blocks: vec![
+                        MarkdownBlock::Text(Text::from("Before ")),
+                        MarkdownBlock::Image {
+                            url: "pic.png".to_string(),
+                            alt: "first line second line".to_string(),
+                            title: None,
                         },
                         MarkdownBlock::Text(Text::from(" after")),
                     ],

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -52,9 +52,11 @@ use syntect::{
 };
 use tracing::{debug, instrument, warn};
 
+pub use crate::content::{MarkdownBlock, MarkdownContent};
 pub use crate::options::Options;
 pub use crate::style_sheet::{DefaultStyleSheet, StyleSheet};
 
+mod content;
 mod options;
 mod style_sheet;
 
@@ -97,6 +99,35 @@ where
     let mut writer = TextWriter::new(parser, options.styles.clone());
     writer.run();
     writer.text
+}
+
+/// Parse Markdown `input` into structured content using the default [`Options`].
+///
+/// Unlike [`from_str`], images are represented as separate [`MarkdownBlock::Image`] blocks rather
+/// than being flattened to alt text. This allows consumers to provide custom image rendering.
+pub fn parse(input: &str) -> MarkdownContent<'_> {
+    parse_with_options(input, &Options::default())
+}
+
+/// Parse Markdown `input` into structured content using the supplied [`Options`].
+///
+/// See [`parse`] for the difference from [`from_str_with_options`].
+pub fn parse_with_options<'a, S>(input: &'a str, options: &Options<S>) -> MarkdownContent<'a>
+where
+    S: StyleSheet,
+{
+    let mut parse_opts = ParseOptions::empty();
+    parse_opts.insert(ParseOptions::ENABLE_STRIKETHROUGH);
+    parse_opts.insert(ParseOptions::ENABLE_TASKLISTS);
+    parse_opts.insert(ParseOptions::ENABLE_HEADING_ATTRIBUTES);
+    parse_opts.insert(ParseOptions::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+    parse_opts.insert(ParseOptions::ENABLE_SUPERSCRIPT);
+    parse_opts.insert(ParseOptions::ENABLE_SUBSCRIPT);
+    let parser = Parser::new_ext(input, parse_opts);
+
+    let mut writer = TextWriter::with_image_blocks(parser, options.styles.clone());
+    writer.run();
+    writer.into_content()
 }
 
 // Heading attributes collected from pulldown-cmark to render after the heading text.
@@ -188,6 +219,18 @@ struct TextWriter<'a, I, S: StyleSheet> {
     /// Whether we are inside a metadata block.
     in_metadata_block: bool,
 
+    /// Whether to emit image blocks instead of inline alt text.
+    emit_image_blocks: bool,
+
+    /// Accumulated content blocks when `emit_image_blocks` is true.
+    content_blocks: Vec<MarkdownBlock<'a>>,
+
+    /// Whether image alt text is currently being collected.
+    collecting_image_alt: bool,
+
+    /// Buffer for the current image's alt text.
+    image_alt_buffer: String,
+
     needs_newline: bool,
 }
 
@@ -202,6 +245,14 @@ where
     S: StyleSheet,
 {
     fn new(iter: I, styles: S) -> Self {
+        Self::create(iter, styles, false)
+    }
+
+    fn with_image_blocks(iter: I, styles: S) -> Self {
+        Self::create(iter, styles, true)
+    }
+
+    fn create(iter: I, styles: S, emit_image_blocks: bool) -> Self {
         Self {
             iter,
             text: Text::default(),
@@ -218,6 +269,10 @@ where
             styles,
             heading_meta: None,
             in_metadata_block: false,
+            emit_image_blocks,
+            content_blocks: Vec::new(),
+            collecting_image_alt: false,
+            image_alt_buffer: String::new(),
         }
     }
 
@@ -225,6 +280,24 @@ where
         debug!("Running text writer");
         while let Some(event) = self.iter.next() {
             self.handle_event(event);
+        }
+        if self.emit_image_blocks {
+            self.flush_text_block();
+        }
+    }
+
+    /// Flush the current text into a structured text block.
+    fn flush_text_block(&mut self) {
+        let text = std::mem::take(&mut self.text);
+        if !text.lines.is_empty() {
+            self.content_blocks.push(MarkdownBlock::Text(text));
+        }
+    }
+
+    /// Consume this writer and return its structured content.
+    fn into_content(self) -> MarkdownContent<'a> {
+        MarkdownContent {
+            blocks: self.content_blocks,
         }
     }
 
@@ -365,6 +438,11 @@ where
     }
 
     fn text(&mut self, text: CowStr<'a>) {
+        if self.collecting_image_alt {
+            self.image_alt_buffer.push_str(&text);
+            return;
+        }
+
         if self.image_url.is_some() {
             self.image_had_alt = true;
         }
@@ -615,14 +693,33 @@ where
     fn start_image(&mut self, dest_url: CowStr<'a>) {
         self.image_url = Some(dest_url);
         self.image_had_alt = false;
-        let style = self.styles.image_alt();
-        self.push_inline_style(style);
-        self.push_span(Span::styled(format!("{IMAGE_INDICATOR} "), style));
+        if self.emit_image_blocks {
+            self.collecting_image_alt = true;
+            self.image_alt_buffer.clear();
+        } else {
+            let style = self.styles.image_alt();
+            self.push_inline_style(style);
+            self.push_span(Span::styled(format!("{IMAGE_INDICATOR} "), style));
+        }
     }
 
     /// Render an image as styled alt text, falling back to its URL when the alt text is empty.
     #[instrument(level = "trace", skip(self))]
     fn end_image(&mut self) {
+        if self.emit_image_blocks {
+            self.collecting_image_alt = false;
+            if let Some(url) = self.image_url.take() {
+                self.flush_text_block();
+                self.content_blocks.push(MarkdownBlock::Image {
+                    url: url.into_string(),
+                    alt: std::mem::take(&mut self.image_alt_buffer),
+                    title: None,
+                });
+            }
+            self.image_had_alt = false;
+            return;
+        }
+
         self.pop_inline_style();
         if let Some(url) = self.image_url.take() {
             if !self.image_had_alt {
@@ -1177,7 +1274,6 @@ mod tests {
                 ]))
             );
         }
-
         #[rstest]
         fn multiple_images_in_paragraph(_with_tracing: DefaultGuard) {
             assert_eq!(
@@ -1221,6 +1317,52 @@ mod tests {
                     Span::raw(" after"),
                 ]))
             );
+        }
+
+        #[rstest]
+        fn parse_returns_content_blocks(_with_tracing: DefaultGuard) {
+            let content = parse("Hello world");
+            assert!(!content.blocks.is_empty());
+            match &content.blocks[0] {
+                MarkdownBlock::Text(text) => {
+                    let flat: String = text
+                        .lines
+                        .iter()
+                        .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
+                        .collect();
+                    assert!(flat.contains("Hello world"));
+                }
+                MarkdownBlock::Image { .. } => panic!("expected a text block"),
+            }
+        }
+
+        #[rstest]
+        fn parse_separates_images_as_blocks(_with_tracing: DefaultGuard) {
+            let content = parse("Before\n\n![photo](pic.png)\n\nAfter");
+            let image_count = content
+                .blocks
+                .iter()
+                .filter(|block| matches!(block, MarkdownBlock::Image { .. }))
+                .count();
+            assert_eq!(image_count, 1);
+
+            let image = content
+                .blocks
+                .iter()
+                .find_map(|block| match block {
+                    MarkdownBlock::Image { url, alt, .. } => Some((url, alt)),
+                    MarkdownBlock::Text(_) => None,
+                })
+                .expect("image block");
+            assert_eq!(image.0, "pic.png");
+            assert_eq!(image.1, "photo");
+        }
+
+        #[rstest]
+        fn parse_without_images_returns_one_text_block(_with_tracing: DefaultGuard) {
+            let content = parse("Just text");
+            assert_eq!(content.blocks.len(), 1);
+            assert!(matches!(&content.blocks[0], MarkdownBlock::Text(_)));
         }
     }
 }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -207,6 +207,9 @@ struct TextWriter<'a, I, S: StyleSheet> {
     /// Image destination URL stored between image start and end events.
     image_url: Option<CowStr<'a>>,
 
+    /// Image title stored between image start and end events.
+    image_title: Option<CowStr<'a>>,
+
     /// Whether any alt text was rendered for the current image.
     image_had_alt: bool,
 
@@ -230,6 +233,9 @@ struct TextWriter<'a, I, S: StyleSheet> {
 
     /// Buffer for the current image's alt text.
     image_alt_buffer: String,
+
+    /// Whether leading structural blank lines should be removed from the next text block.
+    trim_leading_text: bool,
 
     needs_newline: bool,
 }
@@ -265,6 +271,7 @@ where
             code_highlighter: None,
             link: None,
             image_url: None,
+            image_title: None,
             image_had_alt: false,
             styles,
             heading_meta: None,
@@ -273,6 +280,7 @@ where
             content_blocks: Vec::new(),
             collecting_image_alt: false,
             image_alt_buffer: String::new(),
+            trim_leading_text: false,
         }
     }
 
@@ -282,13 +290,27 @@ where
             self.handle_event(event);
         }
         if self.emit_image_blocks {
-            self.flush_text_block();
+            self.flush_text_block(false);
         }
     }
 
     /// Flush the current text into a structured text block.
-    fn flush_text_block(&mut self) {
-        let text = std::mem::take(&mut self.text);
+    fn flush_text_block(&mut self, trim_trailing: bool) {
+        let mut text = std::mem::take(&mut self.text);
+        if self.trim_leading_text {
+            let first_content = text
+                .lines
+                .iter()
+                .position(|line| !line.spans.is_empty())
+                .unwrap_or(text.lines.len());
+            text.lines.drain(..first_content);
+            self.trim_leading_text = false;
+        }
+        if trim_trailing {
+            while text.lines.last().is_some_and(|line| line.spans.is_empty()) {
+                text.lines.pop();
+            }
+        }
         if !text.lines.is_empty() {
             self.content_blocks.push(MarkdownBlock::Text(text));
         }
@@ -345,7 +367,9 @@ where
             Tag::Subscript => self.push_inline_style(Style::new().dim().italic()),
             Tag::Superscript => self.push_inline_style(Style::new().dim().italic()),
             Tag::Link { dest_url, .. } => self.push_link(dest_url),
-            Tag::Image { dest_url, .. } => self.start_image(dest_url),
+            Tag::Image {
+                dest_url, title, ..
+            } => self.start_image(dest_url, title),
             Tag::MetadataBlock(_) => self.start_metadata_block(),
             Tag::DefinitionList => warn!("Definition list not yet supported"),
             Tag::DefinitionListTitle => warn!("Definition list title not yet supported"),
@@ -690,8 +714,9 @@ where
 
     /// Store the image URL and style its alt text.
     #[instrument(level = "trace", skip(self))]
-    fn start_image(&mut self, dest_url: CowStr<'a>) {
+    fn start_image(&mut self, dest_url: CowStr<'a>, title: CowStr<'a>) {
         self.image_url = Some(dest_url);
+        self.image_title = (!title.is_empty()).then_some(title);
         self.image_had_alt = false;
         if self.emit_image_blocks {
             self.collecting_image_alt = true;
@@ -709,18 +734,20 @@ where
         if self.emit_image_blocks {
             self.collecting_image_alt = false;
             if let Some(url) = self.image_url.take() {
-                self.flush_text_block();
+                self.flush_text_block(true);
                 self.content_blocks.push(MarkdownBlock::Image {
                     url: url.into_string(),
                     alt: std::mem::take(&mut self.image_alt_buffer),
-                    title: None,
+                    title: self.image_title.take().map(CowStr::into_string),
                 });
+                self.trim_leading_text = true;
             }
             self.image_had_alt = false;
             return;
         }
 
         self.pop_inline_style();
+        self.image_title = None;
         if let Some(url) = self.image_url.take() {
             if !self.image_had_alt {
                 self.push_span(Span::styled(url, self.styles.image_alt()));
@@ -1363,6 +1390,89 @@ mod tests {
             let content = parse("Just text");
             assert_eq!(content.blocks.len(), 1);
             assert!(matches!(&content.blocks[0], MarkdownBlock::Text(_)));
+        }
+
+        #[rstest]
+        fn parse_preserves_inline_image_order_and_title(_with_tracing: DefaultGuard) {
+            let content = parse("Before ![photo](pic.png \"A photo\") after");
+
+            assert_eq!(
+                content,
+                MarkdownContent {
+                    blocks: vec![
+                        MarkdownBlock::Text(Text::from("Before ")),
+                        MarkdownBlock::Image {
+                            url: "pic.png".to_string(),
+                            alt: "photo".to_string(),
+                            title: Some("A photo".to_string()),
+                        },
+                        MarkdownBlock::Text(Text::from(" after")),
+                    ],
+                }
+            );
+        }
+
+        #[rstest]
+        fn parse_does_not_emit_empty_text_around_leading_image(_with_tracing: DefaultGuard) {
+            let content = parse("![photo](pic.png) after");
+
+            assert_eq!(
+                content,
+                MarkdownContent {
+                    blocks: vec![
+                        MarkdownBlock::Image {
+                            url: "pic.png".to_string(),
+                            alt: "photo".to_string(),
+                            title: None,
+                        },
+                        MarkdownBlock::Text(Text::from(" after")),
+                    ],
+                }
+            );
+        }
+
+        #[rstest]
+        fn parse_separates_block_image_without_blank_text(_with_tracing: DefaultGuard) {
+            let content = parse("Before\n\n![photo](pic.png)\n\nAfter");
+
+            assert_eq!(
+                content,
+                MarkdownContent {
+                    blocks: vec![
+                        MarkdownBlock::Text(Text::from("Before")),
+                        MarkdownBlock::Image {
+                            url: "pic.png".to_string(),
+                            alt: "photo".to_string(),
+                            title: None,
+                        },
+                        MarkdownBlock::Text(Text::from("After")),
+                    ],
+                }
+            );
+        }
+
+        #[rstest]
+        fn parse_preserves_order_for_multiple_images(_with_tracing: DefaultGuard) {
+            let content = parse("![one](one.png) and ![two](two.png)");
+
+            assert_eq!(
+                content,
+                MarkdownContent {
+                    blocks: vec![
+                        MarkdownBlock::Image {
+                            url: "one.png".to_string(),
+                            alt: "one".to_string(),
+                            title: None,
+                        },
+                        MarkdownBlock::Text(Text::from(" and ")),
+                        MarkdownBlock::Image {
+                            url: "two.png".to_string(),
+                            alt: "two".to_string(),
+                            title: None,
+                        },
+                    ],
+                }
+            );
         }
     }
 }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -403,7 +403,15 @@ where
     }
 
     fn code(&mut self, code: CowStr<'a>) {
-        let span = Span::styled(code, self.styles.code());
+        let style = if self.image_url.is_some() {
+            self.image_had_alt = true;
+            let image_style = self.inline_styles.last().copied().unwrap_or_default();
+            image_style.patch(self.styles.code())
+        } else {
+            self.styles.code()
+        };
+
+        let span = Span::styled(code, style);
         self.push_span(span);
     }
 
@@ -607,7 +615,9 @@ where
     fn start_image(&mut self, dest_url: CowStr<'a>) {
         self.image_url = Some(dest_url);
         self.image_had_alt = false;
-        self.push_inline_style(self.styles.image_alt());
+        let style = self.styles.image_alt();
+        self.push_inline_style(style);
+        self.push_span(Span::styled(format!("{IMAGE_INDICATOR} "), style));
     }
 
     /// Render an image as styled alt text, falling back to its URL when the alt text is empty.
@@ -615,18 +625,8 @@ where
     fn end_image(&mut self) {
         self.pop_inline_style();
         if let Some(url) = self.image_url.take() {
-            let style = self.styles.image_alt();
-            let prefix = format!("{IMAGE_INDICATOR} ");
-            if self.image_had_alt {
-                if let Some(line) = self.text.lines.last_mut() {
-                    if let Some(span) = line.spans.iter_mut().find(|span| span.style == style) {
-                        span.content.to_mut().insert_str(0, &prefix);
-                    } else {
-                        line.spans.push(Span::styled(prefix, style));
-                    }
-                }
-            } else {
-                self.push_span(Span::styled(format!("{prefix}{url}"), style));
+            if !self.image_had_alt {
+                self.push_span(Span::styled(url, self.styles.image_alt()));
             }
         }
         self.image_had_alt = false;
@@ -1099,11 +1099,47 @@ mod tests {
 
         const IMAGE_STYLE: Style = Style::new().dim().italic();
 
+        #[derive(Clone)]
+        struct UnstyledImageStyleSheet;
+
+        impl StyleSheet for UnstyledImageStyleSheet {
+            fn heading(&self, _level: u8) -> Style {
+                Style::default()
+            }
+
+            fn code(&self) -> Style {
+                Style::default()
+            }
+
+            fn link(&self) -> Style {
+                Style::default()
+            }
+
+            fn blockquote(&self) -> Style {
+                Style::default()
+            }
+
+            fn heading_meta(&self) -> Style {
+                Style::default()
+            }
+
+            fn metadata_block(&self) -> Style {
+                Style::default()
+            }
+
+            fn image_alt(&self) -> Style {
+                Style::default()
+            }
+        }
+
         #[rstest]
         fn image_with_alt(_with_tracing: DefaultGuard) {
             assert_eq!(
                 from_str("![Alt text](https://example.com/image.png)"),
-                Text::from(Line::from(Span::styled("[img] Alt text", IMAGE_STYLE)))
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("Alt text", IMAGE_STYLE),
+                ]))
             );
         }
 
@@ -1111,10 +1147,10 @@ mod tests {
         fn image_without_alt(_with_tracing: DefaultGuard) {
             assert_eq!(
                 from_str("![](https://example.com/image.png)"),
-                Text::from(Line::from(Span::styled(
-                    "[img] https://example.com/image.png",
-                    IMAGE_STYLE,
-                )))
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("https://example.com/image.png", IMAGE_STYLE),
+                ]))
             );
         }
 
@@ -1122,7 +1158,10 @@ mod tests {
         fn image_with_title(_with_tracing: DefaultGuard) {
             assert_eq!(
                 from_str("![Alt](https://example.com/img.png \"My Title\")"),
-                Text::from(Line::from(Span::styled("[img] Alt", IMAGE_STYLE)))
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("Alt", IMAGE_STYLE),
+                ]))
             );
         }
 
@@ -1132,8 +1171,54 @@ mod tests {
                 from_str("Before ![photo](url.png) after"),
                 Text::from(Line::from_iter([
                     Span::from("Before "),
-                    Span::styled("[img] photo", IMAGE_STYLE),
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("photo", IMAGE_STYLE),
                     Span::from(" after"),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn multiple_images_in_paragraph(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![first](first.png) and ![second](second.png)").to_string(),
+                "[img] first and [img] second"
+            );
+        }
+
+        #[rstest]
+        fn formatted_alt_text_keeps_prefix_before_content(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![**bold**](image.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("bold", IMAGE_STYLE.bold()),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn inline_code_counts_as_alt_text(_with_tracing: DefaultGuard) {
+            let code_style = IMAGE_STYLE.patch(DefaultStyleSheet.code());
+            assert_eq!(
+                from_str("![`code`](image.png)"),
+                Text::from(Line::from_iter([
+                    Span::styled("[img] ", IMAGE_STYLE),
+                    Span::styled("code", code_style),
+                ]))
+            );
+        }
+
+        #[rstest]
+        fn unstyled_fallback_does_not_modify_surrounding_text(_with_tracing: DefaultGuard) {
+            let options = Options::new(UnstyledImageStyleSheet);
+            assert_eq!(
+                from_str_with_options("Before ![photo](photo.png) after", &options),
+                Text::from(Line::from_iter([
+                    Span::raw("Before "),
+                    Span::raw("[img] "),
+                    Span::raw("photo"),
+                    Span::raw(" after"),
                 ]))
             );
         }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -58,6 +58,8 @@ pub use crate::style_sheet::{DefaultStyleSheet, StyleSheet};
 mod options;
 mod style_sheet;
 
+const IMAGE_INDICATOR: &str = "[img]";
+
 /// Render Markdown `input` into a [`Text`] using the default [`Options`].
 ///
 /// This is a convenience function that uses the default options, which are defined in
@@ -171,6 +173,12 @@ struct TextWriter<'a, I, S: StyleSheet> {
     /// A link which will be appended to the current line when the link tag is closed.
     link: Option<CowStr<'a>>,
 
+    /// Image destination URL stored between image start and end events.
+    image_url: Option<CowStr<'a>>,
+
+    /// Whether any alt text was rendered for the current image.
+    image_had_alt: bool,
+
     /// The [`StyleSheet`] to use to style the output.
     styles: S,
 
@@ -205,6 +213,8 @@ where
             #[cfg(feature = "highlight-code")]
             code_highlighter: None,
             link: None,
+            image_url: None,
+            image_had_alt: false,
             styles,
             heading_meta: None,
             in_metadata_block: false,
@@ -262,7 +272,7 @@ where
             Tag::Subscript => self.push_inline_style(Style::new().dim().italic()),
             Tag::Superscript => self.push_inline_style(Style::new().dim().italic()),
             Tag::Link { dest_url, .. } => self.push_link(dest_url),
-            Tag::Image { .. } => warn!("Image not yet supported"),
+            Tag::Image { dest_url, .. } => self.start_image(dest_url),
             Tag::MetadataBlock(_) => self.start_metadata_block(),
             Tag::DefinitionList => warn!("Definition list not yet supported"),
             Tag::DefinitionListTitle => warn!("Definition list title not yet supported"),
@@ -290,7 +300,7 @@ where
             TagEnd::Subscript => self.pop_inline_style(),
             TagEnd::Superscript => self.pop_inline_style(),
             TagEnd::Link => self.pop_link(),
-            TagEnd::Image => {}
+            TagEnd::Image => self.end_image(),
             TagEnd::MetadataBlock(_) => self.end_metadata_block(),
             TagEnd::DefinitionList => {}
             TagEnd::DefinitionListTitle => {}
@@ -355,6 +365,10 @@ where
     }
 
     fn text(&mut self, text: CowStr<'a>) {
+        if self.image_url.is_some() {
+            self.image_had_alt = true;
+        }
+
         #[cfg(feature = "highlight-code")]
         if let Some(highlighter) = &mut self.code_highlighter {
             let text: Text = LinesWithEndings::from(&text)
@@ -586,6 +600,36 @@ where
             self.push_span(Span::styled(link, self.styles.link()));
             self.push_span(")".into());
         }
+    }
+
+    /// Store the image URL and style its alt text.
+    #[instrument(level = "trace", skip(self))]
+    fn start_image(&mut self, dest_url: CowStr<'a>) {
+        self.image_url = Some(dest_url);
+        self.image_had_alt = false;
+        self.push_inline_style(self.styles.image_alt());
+    }
+
+    /// Render an image as styled alt text, falling back to its URL when the alt text is empty.
+    #[instrument(level = "trace", skip(self))]
+    fn end_image(&mut self) {
+        self.pop_inline_style();
+        if let Some(url) = self.image_url.take() {
+            let style = self.styles.image_alt();
+            let prefix = format!("{IMAGE_INDICATOR} ");
+            if self.image_had_alt {
+                if let Some(line) = self.text.lines.last_mut() {
+                    if let Some(span) = line.spans.iter_mut().find(|span| span.style == style) {
+                        span.content.to_mut().insert_str(0, &prefix);
+                    } else {
+                        line.spans.push(Span::styled(prefix, style));
+                    }
+                }
+            } else {
+                self.push_span(Span::styled(format!("{prefix}{url}"), style));
+            }
+        }
+        self.image_had_alt = false;
     }
 }
 
@@ -1046,5 +1090,52 @@ mod tests {
                 Span::from(")")
             ]))
         );
+    }
+
+    mod image {
+        use pretty_assertions::assert_eq;
+
+        use super::*;
+
+        const IMAGE_STYLE: Style = Style::new().dim().italic();
+
+        #[rstest]
+        fn image_with_alt(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![Alt text](https://example.com/image.png)"),
+                Text::from(Line::from(Span::styled("[img] Alt text", IMAGE_STYLE)))
+            );
+        }
+
+        #[rstest]
+        fn image_without_alt(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![](https://example.com/image.png)"),
+                Text::from(Line::from(Span::styled(
+                    "[img] https://example.com/image.png",
+                    IMAGE_STYLE,
+                )))
+            );
+        }
+
+        #[rstest]
+        fn image_with_title(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("![Alt](https://example.com/img.png \"My Title\")"),
+                Text::from(Line::from(Span::styled("[img] Alt", IMAGE_STYLE)))
+            );
+        }
+
+        #[rstest]
+        fn image_in_paragraph(_with_tracing: DefaultGuard) {
+            assert_eq!(
+                from_str("Before ![photo](url.png) after"),
+                Text::from(Line::from_iter([
+                    Span::from("Before "),
+                    Span::styled("[img] photo", IMAGE_STYLE),
+                    Span::from(" after"),
+                ]))
+            );
+        }
     }
 }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -49,6 +49,10 @@ use crate::{DefaultStyleSheet, StyleSheet};
 ///     fn metadata_block(&self) -> Style {
 ///         Style::new().light_yellow()
 ///     }
+///
+///     fn image_alt(&self) -> Style {
+///         Style::new().dim().italic()
+///     }
 /// }
 ///
 /// let options = Options::new(MyStyleSheet);
@@ -121,6 +125,10 @@ mod tests {
             fn metadata_block(&self) -> Style {
                 Style::new().light_yellow()
             }
+
+            fn image_alt(&self) -> Style {
+                Style::new().dim().italic()
+            }
         }
 
         let options = Options {
@@ -134,5 +142,6 @@ mod tests {
         assert_eq!(options.styles.blockquote(), Style::new().yellow());
         assert_eq!(options.styles.heading_meta(), Style::new().dim());
         assert_eq!(options.styles.metadata_block(), Style::new().light_yellow());
+        assert_eq!(options.styles.image_alt(), Style::new().dim().italic());
     }
 }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -50,9 +50,6 @@ use crate::{DefaultStyleSheet, StyleSheet};
 ///         Style::new().light_yellow()
 ///     }
 ///
-///     fn image_alt(&self) -> Style {
-///         Style::new().dim().italic()
-///     }
 /// }
 ///
 /// let options = Options::new(MyStyleSheet);
@@ -124,10 +121,6 @@ mod tests {
 
             fn metadata_block(&self) -> Style {
                 Style::new().light_yellow()
-            }
-
-            fn image_alt(&self) -> Style {
-                Style::new().dim().italic()
             }
         }
 

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -39,7 +39,9 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
     fn metadata_block(&self) -> Style;
 
     /// Style for the alt-text fallback when rendering images.
-    fn image_alt(&self) -> Style;
+    fn image_alt(&self) -> Style {
+        Style::new().dim().italic()
+    }
 }
 
 /// The default style set

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -37,6 +37,9 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 
     /// Style for metadata blocks (front matter).
     fn metadata_block(&self) -> Style;
+
+    /// Style for the alt-text fallback when rendering images.
+    fn image_alt(&self) -> Style;
 }
 
 /// The default style set
@@ -86,5 +89,9 @@ impl StyleSheet for DefaultStyleSheet {
 
     fn metadata_block(&self) -> Style {
         Style::new().light_yellow()
+    }
+
+    fn image_alt(&self) -> Style {
+        Style::new().dim().italic()
     }
 }

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -38,7 +38,7 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
     /// Style for metadata blocks (front matter).
     fn metadata_block(&self) -> Style;
 
-    /// Style for the alt-text fallback when rendering images.
+    /// Style for image fallback text, including the `[img]` marker and alt text or URL.
     fn image_alt(&self) -> Style {
         Style::new().dim().italic()
     }
@@ -57,6 +57,7 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 /// - link: blue, underlined
 /// - blockquote: green
 /// - metadata block: light yellow
+/// - image fallback text: dim and italic
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DefaultStyleSheet;
 


### PR DESCRIPTION
## Summary

Expose parsed Markdown as ordered text and image segments so applications can render images themselves while retaining the surrounding Ratatui text.

## Example

```rust
use tui_markdown::{parse, MarkdownBlock};

let content = parse("Before ![diagram](diagram.png \"Architecture\") after");
for segment in content.blocks {
    match segment {
        MarkdownBlock::Text(text) => { /* render with Ratatui */ }
        MarkdownBlock::Image { url, alt, title } => {
            // Render `url` with an image protocol and use `alt` as fallback text.
        }
    }
}
```

Inline images split surrounding text into ordered text/image/text segments. Image segments retain URL, plain alt text, and optional title.

## Stacking

Depends on [#155](https://github.com/joshka/tui-markdown/pull/155), which introduces image text fallbacks.

## Documentation and tests

- Adds `parse()` and `parse_with_options()` returning `MarkdownContent`.
- Clarifies that `MarkdownBlock` values are render segments rather than Markdown block syntax.
- Preserves formatted, inline-code, multiline, leading, trailing, adjacent, and block-image boundaries.
- Leaves the existing `from_str()` text-rendering API unchanged.

## Attribution

Originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125), with maintainer follow-up for titles, segment boundaries, ordering, and formatted alt text.

## Validation

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, and warning-denied documentation builds.
