### PR TITLE
feat(options): configure built-in code themes

### DIFF
--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -29,16 +29,18 @@ text.render(area, &mut buf);
 ### Syntax highlighting themes
 
 With the default `highlight-code` feature enabled, fenced code blocks use a built-in syntax
-highlighting theme. Use `available_themes` to discover theme names and pass one to the rendering
-options:
+highlighting theme. Construct a [`CodeTheme`] from one of the bundled themes, then pass that
+renderer-ready theme through the rendering options:
 
 ```rust
-use tui_markdown::{available_themes, from_str_with_options, Options};
+use tui_markdown::{BuiltinCodeTheme, CodeTheme, Options, from_str_with_options};
 
-assert!(available_themes().contains(&"InspiredGitHub"));
-let options = Options::default().code_theme("InspiredGitHub");
+let theme = CodeTheme::builtin(BuiltinCodeTheme::InspiredGitHub);
+let options = Options::default().code_theme(theme);
 let text = from_str_with_options("```rust\nfn main() {}\n```", &options);
 ```
+
+[`CodeTheme`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html
 
 ## Status
 

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -29,21 +29,20 @@ text.render(area, &mut buf);
 ### Syntax highlighting themes
 
 With the default `highlight-code` feature enabled, fenced code blocks whose language is recognized
-use the built-in `Base16OceanDark` syntax-highlighting theme. Construct a [`CodeTheme`] to select a
-different bundled theme:
+use the built-in `Base16OceanDark` syntax-highlighting theme. Pass a [`BuiltinCodeTheme`] to select
+a different bundled theme:
 
 ```rust
-use tui_markdown::{from_str_with_options, BuiltinCodeTheme, CodeTheme, Options};
+use tui_markdown::{from_str_with_options, BuiltinCodeTheme, Options};
 
-let theme = CodeTheme::builtin(BuiltinCodeTheme::InspiredGitHub);
-let options = Options::default().code_theme(theme);
+let options = Options::default().code_theme(BuiltinCodeTheme::InspiredGitHub);
 let markdown = r#"```rust
 fn main() {}
 ```"#;
 let text = from_str_with_options(markdown, &options);
 ```
 
-[`CodeTheme`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html
+[`BuiltinCodeTheme`]: https://docs.rs/tui-markdown/latest/tui_markdown/enum.BuiltinCodeTheme.html
 
 ## Status
 

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -28,16 +28,19 @@ text.render(area, &mut buf);
 
 ### Syntax highlighting themes
 
-With the default `highlight-code` feature enabled, fenced code blocks use a built-in syntax
-highlighting theme. Construct a [`CodeTheme`] from one of the bundled themes, then pass that
-renderer-ready theme through the rendering options:
+With the default `highlight-code` feature enabled, fenced code blocks whose language is recognized
+use the built-in `Base16OceanDark` syntax-highlighting theme. Construct a [`CodeTheme`] to select a
+different bundled theme:
 
 ```rust
-use tui_markdown::{BuiltinCodeTheme, CodeTheme, Options, from_str_with_options};
+use tui_markdown::{from_str_with_options, BuiltinCodeTheme, CodeTheme, Options};
 
 let theme = CodeTheme::builtin(BuiltinCodeTheme::InspiredGitHub);
 let options = Options::default().code_theme(theme);
-let text = from_str_with_options("```rust\nfn main() {}\n```", &options);
+let markdown = r#"```rust
+fn main() {}
+```"#;
+let text = from_str_with_options(markdown, &options);
 ```
 
 [`CodeTheme`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -26,6 +26,20 @@ let text = tui_markdown::from_str(input);
 text.render(area, &mut buf);
 ```
 
+### Syntax highlighting themes
+
+With the default `highlight-code` feature enabled, fenced code blocks use a built-in syntax
+highlighting theme. Use `available_themes` to discover theme names and pass one to the rendering
+options:
+
+```rust
+use tui_markdown::{available_themes, from_str_with_options, Options};
+
+assert!(available_themes().contains(&"InspiredGitHub"));
+let options = Options::default().code_theme("InspiredGitHub");
+let text = from_str_with_options("```rust\nfn main() {}\n```", &options);
+```
+
 ## Status
 
 This is working code, but not every markdown feature is supported. PRs welcome!

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -1,58 +1,127 @@
-//! Built-in syntax-highlighting theme discovery and selection.
+//! Syntax-highlighting themes for fenced code blocks.
 //!
-//! Resolve the configured name before parsing events so an unknown name produces one warning per
-//! rendered document rather than one warning for every fenced code block.
+//! [`CodeTheme`] represents a theme that is ready for the renderer to use. How the theme was
+//! obtained is deliberately not part of the rendering options: built-in themes and themes loaded
+//! from other sources have the same type once constructed.
 
+use std::borrow::Cow;
 use std::sync::LazyLock;
 
 use syntect::highlighting::{Theme, ThemeSet};
-use tracing::warn;
 
-use crate::DEFAULT_CODE_THEME;
+/// A syntax-highlighting theme that is ready to render fenced code blocks.
+///
+/// Construct a bundled theme with [`CodeTheme::builtin`], then pass it to
+/// [`Options::code_theme`](crate::Options::code_theme). The default is
+/// [`BuiltinCodeTheme::Base16OceanDark`].
+///
+/// This type hides the syntax-highlighting backend so applications do not need to depend on its
+/// types or version.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CodeTheme {
+    backend: Cow<'static, Theme>,
+}
+
+impl CodeTheme {
+    /// Constructs a theme from one bundled with tui-markdown.
+    #[must_use]
+    pub fn builtin(theme: BuiltinCodeTheme) -> Self {
+        Self {
+            backend: Cow::Borrowed(builtin_theme(theme)),
+        }
+    }
+}
+
+impl Default for CodeTheme {
+    fn default() -> Self {
+        Self::builtin(BuiltinCodeTheme::default())
+    }
+}
+
+/// A syntax-highlighting theme bundled with tui-markdown.
+///
+/// Use this type to select a bundled theme, then construct a renderer-ready [`CodeTheme`] with
+/// [`CodeTheme::builtin`].
+#[non_exhaustive]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BuiltinCodeTheme {
+    /// The dark Base16 Eighties theme.
+    Base16EightiesDark,
+    /// The dark Base16 Mocha theme.
+    Base16MochaDark,
+    /// The default dark Base16 Ocean theme.
+    #[default]
+    Base16OceanDark,
+    /// The light Base16 Ocean theme.
+    Base16OceanLight,
+    /// The light Inspired GitHub theme.
+    InspiredGitHub,
+    /// The dark Solarized theme.
+    SolarizedDark,
+    /// The light Solarized theme.
+    SolarizedLight,
+}
+
+impl BuiltinCodeTheme {
+    fn backend_name(self) -> &'static str {
+        match self {
+            Self::Base16EightiesDark => "base16-eighties.dark",
+            Self::Base16MochaDark => "base16-mocha.dark",
+            Self::Base16OceanDark => "base16-ocean.dark",
+            Self::Base16OceanLight => "base16-ocean.light",
+            Self::InspiredGitHub => "InspiredGitHub",
+            Self::SolarizedDark => "Solarized (dark)",
+            Self::SolarizedLight => "Solarized (light)",
+        }
+    }
+}
+
+/// Returns the backend theme represented by a public theme.
+pub fn backend_theme(theme: &CodeTheme) -> &Theme {
+    theme.backend.as_ref()
+}
+
+/// Returns the backend theme used when no configured theme has been applied yet.
+pub fn default_backend_theme() -> &'static Theme {
+    builtin_theme(BuiltinCodeTheme::default())
+}
+
+fn builtin_theme(theme: BuiltinCodeTheme) -> &'static Theme {
+    THEMES
+        .themes
+        .get(theme.backend_name())
+        .expect("every BuiltinCodeTheme variant must map to a bundled theme")
+}
 
 static THEMES: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
-
-/// Returns the names of all built-in syntax-highlighting themes.
-///
-/// Pass one of these names to [`crate::Options::code_theme`]. Code blocks use
-/// [`DEFAULT_CODE_THEME`] when no theme is selected.
-///
-/// This function is available with the `highlight-code` feature, which is enabled by default.
-///
-/// # Example
-///
-/// ```
-/// use tui_markdown::{available_themes, Options};
-///
-/// assert!(available_themes().contains(&"InspiredGitHub"));
-/// let options = Options::default().code_theme("InspiredGitHub");
-/// ```
-pub fn available_themes() -> Vec<&'static str> {
-    THEMES.themes.keys().map(String::as_str).collect()
-}
-
-/// Returns the default built-in theme.
-pub fn default_theme() -> &'static Theme {
-    &THEMES.themes[DEFAULT_CODE_THEME]
-}
-
-/// Resolves a requested theme name, falling back to the default when the name is unknown.
-pub fn resolve(name: &str) -> &'static Theme {
-    THEMES.themes.get(name).unwrap_or_else(|| {
-        warn!("Theme {name:?} not found, falling back to {DEFAULT_CODE_THEME:?}");
-        default_theme()
-    })
-}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn available_themes_include_the_default_and_documented_example() {
-        let themes = available_themes();
+    fn ocean_dark_is_the_default() {
+        let default = CodeTheme::default();
+        let ocean_dark = CodeTheme::builtin(BuiltinCodeTheme::Base16OceanDark);
 
-        assert!(themes.contains(&DEFAULT_CODE_THEME));
-        assert!(themes.contains(&"InspiredGitHub"));
+        assert_eq!(default, ocean_dark);
+    }
+
+    #[test]
+    fn every_builtin_theme_has_a_backend_theme() {
+        let themes = [
+            BuiltinCodeTheme::Base16EightiesDark,
+            BuiltinCodeTheme::Base16MochaDark,
+            BuiltinCodeTheme::Base16OceanDark,
+            BuiltinCodeTheme::Base16OceanLight,
+            BuiltinCodeTheme::InspiredGitHub,
+            BuiltinCodeTheme::SolarizedDark,
+            BuiltinCodeTheme::SolarizedLight,
+        ];
+
+        for theme in themes {
+            let theme = CodeTheme::builtin(theme);
+            let _ = backend_theme(&theme);
+        }
     }
 }

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -1,0 +1,58 @@
+//! Built-in syntax-highlighting theme discovery and selection.
+//!
+//! Resolve the configured name before parsing events so an unknown name produces one warning per
+//! rendered document rather than one warning for every fenced code block.
+
+use std::sync::LazyLock;
+
+use syntect::highlighting::{Theme, ThemeSet};
+use tracing::warn;
+
+use crate::DEFAULT_CODE_THEME;
+
+static THEMES: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
+
+/// Returns the names of all built-in syntax-highlighting themes.
+///
+/// Pass one of these names to [`crate::Options::code_theme`]. Code blocks use
+/// [`DEFAULT_CODE_THEME`] when no theme is selected.
+///
+/// This function is available with the `highlight-code` feature, which is enabled by default.
+///
+/// # Example
+///
+/// ```
+/// use tui_markdown::{available_themes, Options};
+///
+/// assert!(available_themes().contains(&"InspiredGitHub"));
+/// let options = Options::default().code_theme("InspiredGitHub");
+/// ```
+pub fn available_themes() -> Vec<&'static str> {
+    THEMES.themes.keys().map(String::as_str).collect()
+}
+
+/// Returns the default built-in theme.
+pub fn default_theme() -> &'static Theme {
+    &THEMES.themes[DEFAULT_CODE_THEME]
+}
+
+/// Resolves a requested theme name, falling back to the default when the name is unknown.
+pub fn resolve(name: &str) -> &'static Theme {
+    THEMES.themes.get(name).unwrap_or_else(|| {
+        warn!("Theme {name:?} not found, falling back to {DEFAULT_CODE_THEME:?}");
+        default_theme()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn available_themes_include_the_default_and_documented_example() {
+        let themes = available_themes();
+
+        assert!(themes.contains(&DEFAULT_CODE_THEME));
+        assert!(themes.contains(&"InspiredGitHub"));
+    }
+}

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -5,8 +5,8 @@
 //! recognized language.
 //!
 //! A configured [`CodeTheme`] owns its theme data. [`Options`](crate::Options) stores no theme by
-//! default; the renderer instead borrows the shared [`BuiltinCodeTheme::Base16OceanDark`] theme
-//! when it first encounters a recognized fenced language.
+//! default; the renderer instead borrows a shared [`CodeTheme`] for
+//! [`BuiltinCodeTheme::Base16OceanDark`] when it first encounters a recognized fenced language.
 
 use std::sync::LazyLock;
 
@@ -19,28 +19,11 @@ use syntect::highlighting::{Theme, ThemeSet};
 ///
 /// The renderer consults the theme only for fenced code blocks whose language is recognized.
 ///
-/// This type hides the syntax-highlighting backend so applications do not need to depend on its
-/// types or version.
-///
-/// [`CodeTheme::default`] constructs an owned [`BuiltinCodeTheme::Base16OceanDark`] theme. Default
-/// [`Options`](crate::Options), however, leave the theme unset so the renderer can borrow its shared
-/// copy of that theme.
+/// This type hides the syntax-highlighting implementation so applications do not need to depend on
+/// its types or version.
 #[derive(Clone, Debug)]
 pub struct CodeTheme {
     theme: Theme,
-}
-
-impl From<BuiltinCodeTheme> for CodeTheme {
-    fn from(theme: BuiltinCodeTheme) -> Self {
-        let theme = builtin_theme(theme).clone();
-        Self { theme }
-    }
-}
-
-impl Default for CodeTheme {
-    fn default() -> Self {
-        BuiltinCodeTheme::default().into()
-    }
 }
 
 /// A syntax-highlighting theme bundled with tui-markdown.
@@ -81,29 +64,34 @@ impl BuiltinCodeTheme {
     }
 }
 
-/// Returns the configured theme or the shared default.
-///
-/// The renderer calls this only after recognizing a fenced language. Keeping the choice here means
-/// ordinary Markdown and unrecognized code fences do not initialize the bundled theme set, while
-/// default options can borrow the shared theme instead of cloning it.
-pub fn theme_or_default(theme: Option<&CodeTheme>) -> &Theme {
-    match theme {
-        Some(theme) => &theme.theme,
-        None => default_theme(),
+impl From<BuiltinCodeTheme> for CodeTheme {
+    fn from(theme: BuiltinCodeTheme) -> Self {
+        let theme = builtin_theme(theme).clone();
+        Self { theme }
     }
 }
 
-fn builtin_theme(theme: BuiltinCodeTheme) -> &'static Theme {
+/// Returns the syntax-highlighting data for a code theme.
+pub fn theme(code_theme: &CodeTheme) -> &Theme {
+    &code_theme.theme
+}
+
+/// Returns the lazily initialized default code theme.
+///
+/// The renderer calls this only after recognizing a fenced language, so ordinary Markdown and
+/// unrecognized code fences do not initialize the bundled theme set.
+pub fn default() -> &'static CodeTheme {
+    &DEFAULT_THEME
+}
+
+fn builtin_theme(code_theme: BuiltinCodeTheme) -> &'static Theme {
     THEMES
         .themes
-        .get(theme.syntect_name())
+        .get(code_theme.syntect_name())
         .expect("every BuiltinCodeTheme variant must map to a bundled theme")
 }
 
-fn default_theme() -> &'static Theme {
-    builtin_theme(BuiltinCodeTheme::default())
-}
-
+static DEFAULT_THEME: LazyLock<CodeTheme> = LazyLock::new(|| BuiltinCodeTheme::default().into());
 static THEMES: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
 
 #[cfg(test)]
@@ -122,21 +110,21 @@ mod tests {
             BuiltinCodeTheme::SolarizedLight,
         ];
 
-        for theme in themes {
-            let theme = CodeTheme::from(theme);
-            let _ = theme_or_default(Some(&theme));
+        for built_in in themes {
+            let code_theme = CodeTheme::from(built_in);
+            let _ = theme(&code_theme);
         }
     }
 
     #[test]
     fn configured_theme_is_borrowed_directly() {
-        let theme = CodeTheme::from(BuiltinCodeTheme::SolarizedDark);
+        let code_theme = CodeTheme::from(BuiltinCodeTheme::SolarizedDark);
 
-        assert!(std::ptr::eq(theme_or_default(Some(&theme)), &theme.theme));
+        assert!(std::ptr::eq(theme(&code_theme), &code_theme.theme));
     }
 
     #[test]
-    fn absent_theme_uses_shared_default() {
-        assert!(std::ptr::eq(theme_or_default(None), default_theme()));
+    fn default_theme_is_shared() {
+        assert!(std::ptr::eq(default(), default()));
     }
 }

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -4,7 +4,6 @@
 //! obtained is deliberately not part of the rendering options: built-in themes and themes loaded
 //! from other sources have the same type once constructed.
 
-use std::borrow::Cow;
 use std::sync::LazyLock;
 
 use syntect::highlighting::{Theme, ThemeSet};
@@ -19,7 +18,12 @@ use syntect::highlighting::{Theme, ThemeSet};
 /// types or version.
 #[derive(Clone, Debug)]
 pub struct CodeTheme {
-    backend: Cow<'static, Theme>,
+    backend: CodeThemeBackend,
+}
+
+#[derive(Clone, Debug)]
+enum CodeThemeBackend {
+    Builtin(BuiltinCodeTheme),
 }
 
 impl CodeTheme {
@@ -27,7 +31,7 @@ impl CodeTheme {
     #[must_use]
     pub fn builtin(theme: BuiltinCodeTheme) -> Self {
         Self {
-            backend: Cow::Borrowed(builtin_theme(theme)),
+            backend: CodeThemeBackend::Builtin(theme),
         }
     }
 }
@@ -78,12 +82,17 @@ impl BuiltinCodeTheme {
 
 /// Returns the backend theme represented by a public theme.
 pub fn backend_theme(theme: &CodeTheme) -> &Theme {
-    theme.backend.as_ref()
+    match &theme.backend {
+        CodeThemeBackend::Builtin(theme) => builtin_theme(*theme),
+    }
 }
 
-/// Returns the backend theme used when no configured theme has been applied yet.
-pub fn default_backend_theme() -> &'static Theme {
-    builtin_theme(BuiltinCodeTheme::default())
+/// Returns the unresolved default theme used until options are applied.
+pub fn default_code_theme() -> &'static CodeTheme {
+    static DEFAULT: CodeTheme = CodeTheme {
+        backend: CodeThemeBackend::Builtin(BuiltinCodeTheme::Base16OceanDark),
+    };
+    &DEFAULT
 }
 
 fn builtin_theme(theme: BuiltinCodeTheme) -> &'static Theme {
@@ -102,11 +111,10 @@ mod tests {
     #[test]
     fn ocean_dark_is_the_default() {
         let default = CodeTheme::default();
-        let ocean_dark = CodeTheme::builtin(BuiltinCodeTheme::Base16OceanDark);
 
-        assert!(std::ptr::eq(
-            backend_theme(&default),
-            backend_theme(&ocean_dark)
+        assert!(matches!(
+            default.backend,
+            CodeThemeBackend::Builtin(BuiltinCodeTheme::Base16OceanDark)
         ));
     }
 

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -18,11 +18,11 @@ use syntect::highlighting::{Theme, ThemeSet};
 /// types or version.
 #[derive(Clone, Debug)]
 pub struct CodeTheme {
-    backend: CodeThemeBackend,
+    source: ThemeSource,
 }
 
 #[derive(Clone, Debug)]
-enum CodeThemeBackend {
+enum ThemeSource {
     Builtin(BuiltinCodeTheme),
 }
 
@@ -31,7 +31,7 @@ impl CodeTheme {
     #[must_use]
     pub fn builtin(theme: BuiltinCodeTheme) -> Self {
         Self {
-            backend: CodeThemeBackend::Builtin(theme),
+            source: ThemeSource::Builtin(theme),
         }
     }
 }
@@ -67,7 +67,7 @@ pub enum BuiltinCodeTheme {
 }
 
 impl BuiltinCodeTheme {
-    fn backend_name(self) -> &'static str {
+    fn syntect_name(self) -> &'static str {
         match self {
             Self::Base16EightiesDark => "base16-eighties.dark",
             Self::Base16MochaDark => "base16-mocha.dark",
@@ -80,17 +80,17 @@ impl BuiltinCodeTheme {
     }
 }
 
-/// Returns the backend theme represented by a public theme.
-pub fn backend_theme(theme: &CodeTheme) -> &Theme {
-    match &theme.backend {
-        CodeThemeBackend::Builtin(theme) => builtin_theme(*theme),
+/// Resolves a public theme to the syntect theme used for highlighting.
+pub fn resolve(theme: &CodeTheme) -> &Theme {
+    match &theme.source {
+        ThemeSource::Builtin(theme) => builtin_theme(*theme),
     }
 }
 
 /// Returns the unresolved default theme used until options are applied.
 pub fn default_code_theme() -> &'static CodeTheme {
     static DEFAULT: CodeTheme = CodeTheme {
-        backend: CodeThemeBackend::Builtin(BuiltinCodeTheme::Base16OceanDark),
+        source: ThemeSource::Builtin(BuiltinCodeTheme::Base16OceanDark),
     };
     &DEFAULT
 }
@@ -98,7 +98,7 @@ pub fn default_code_theme() -> &'static CodeTheme {
 fn builtin_theme(theme: BuiltinCodeTheme) -> &'static Theme {
     THEMES
         .themes
-        .get(theme.backend_name())
+        .get(theme.syntect_name())
         .expect("every BuiltinCodeTheme variant must map to a bundled theme")
 }
 
@@ -113,13 +113,13 @@ mod tests {
         let default = CodeTheme::default();
 
         assert!(matches!(
-            default.backend,
-            CodeThemeBackend::Builtin(BuiltinCodeTheme::Base16OceanDark)
+            default.source,
+            ThemeSource::Builtin(BuiltinCodeTheme::Base16OceanDark)
         ));
     }
 
     #[test]
-    fn every_builtin_theme_has_a_backend_theme() {
+    fn every_builtin_theme_resolves() {
         let themes = [
             BuiltinCodeTheme::Base16EightiesDark,
             BuiltinCodeTheme::Base16MochaDark,
@@ -132,7 +132,7 @@ mod tests {
 
         for theme in themes {
             let theme = CodeTheme::builtin(theme);
-            let _ = backend_theme(&theme);
+            let _ = resolve(&theme);
         }
     }
 }

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -3,28 +3,35 @@
 //! Construct a [`CodeTheme`] with [`CodeTheme::builtin`], then select it with
 //! [`Options::code_theme`](crate::Options::code_theme). The renderer consults the theme when a
 //! fenced code block names a recognized language.
+//!
+//! A configured [`CodeTheme`] owns its theme data. [`Options`](crate::Options) stores no theme by
+//! default; the renderer instead borrows the shared [`BuiltinCodeTheme::Base16OceanDark`] theme
+//! when it first encounters a recognized fenced language.
 
 use std::sync::LazyLock;
 
 use syntect::highlighting::{Theme, ThemeSet};
 
-/// A syntax-highlighting theme for fenced code blocks.
+/// An owned syntax-highlighting theme for fenced code blocks.
 ///
 /// Construct a bundled theme with [`CodeTheme::builtin`], then pass it to
-/// [`Options::code_theme`](crate::Options::code_theme). The default is
-/// [`BuiltinCodeTheme::Base16OceanDark`].
+/// [`Options::code_theme`](crate::Options::code_theme).
 ///
 /// The renderer consults the theme only for fenced code blocks whose language is recognized.
 ///
 /// This type hides the syntax-highlighting backend so applications do not need to depend on its
 /// types or version.
+///
+/// [`CodeTheme::default`] constructs an owned [`BuiltinCodeTheme::Base16OceanDark`] theme. Default
+/// [`Options`](crate::Options), however, leave the theme unset so the renderer can borrow its shared
+/// copy of that theme.
 #[derive(Clone, Debug)]
 pub struct CodeTheme {
     theme: Theme,
 }
 
 impl CodeTheme {
-    /// Selects a syntax-highlighting theme bundled with tui-markdown.
+    /// Constructs an owned syntax-highlighting theme from a bundled theme.
     #[must_use]
     pub fn builtin(theme: BuiltinCodeTheme) -> Self {
         let theme = builtin_theme(theme).clone();
@@ -76,10 +83,11 @@ impl BuiltinCodeTheme {
     }
 }
 
-/// Resolves the configured theme or the shared default.
+/// Returns the configured theme or the shared default.
 ///
-/// Calling this only after recognizing a fenced language avoids initializing the bundled theme set
-/// for ordinary Markdown and code fences that cannot be highlighted.
+/// The renderer calls this only after recognizing a fenced language. Keeping the choice here means
+/// ordinary Markdown and unrecognized code fences do not initialize the bundled theme set, while
+/// default options can borrow the shared theme instead of cloning it.
 pub fn theme_or_default(theme: Option<&CodeTheme>) -> &Theme {
     match theme {
         Some(theme) => &theme.theme,
@@ -105,7 +113,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn every_builtin_theme_resolves() {
+    fn every_builtin_theme_can_be_selected() {
         let themes = [
             BuiltinCodeTheme::Base16EightiesDark,
             BuiltinCodeTheme::Base16MochaDark,
@@ -120,5 +128,17 @@ mod tests {
             let theme = CodeTheme::builtin(theme);
             let _ = theme_or_default(Some(&theme));
         }
+    }
+
+    #[test]
+    fn configured_theme_is_borrowed_directly() {
+        let theme = CodeTheme::builtin(BuiltinCodeTheme::SolarizedDark);
+
+        assert!(std::ptr::eq(theme_or_default(Some(&theme)), &theme.theme));
+    }
+
+    #[test]
+    fn absent_theme_uses_shared_default() {
+        assert!(std::ptr::eq(theme_or_default(None), default_theme()));
     }
 }

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -17,7 +17,7 @@ use syntect::highlighting::{Theme, ThemeSet};
 ///
 /// This type hides the syntax-highlighting backend so applications do not need to depend on its
 /// types or version.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct CodeTheme {
     backend: Cow<'static, Theme>,
 }
@@ -104,7 +104,10 @@ mod tests {
         let default = CodeTheme::default();
         let ocean_dark = CodeTheme::builtin(BuiltinCodeTheme::Base16OceanDark);
 
-        assert_eq!(default, ocean_dark);
+        assert!(std::ptr::eq(
+            backend_theme(&default),
+            backend_theme(&ocean_dark)
+        ));
     }
 
     #[test]

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -1,38 +1,34 @@
-//! Syntax-highlighting themes for fenced code blocks.
+//! Built-in syntax-highlighting themes for fenced code blocks.
 //!
-//! [`CodeTheme`] represents a theme that is ready for the renderer to use. How the theme was
-//! obtained is deliberately not part of the rendering options: built-in themes and themes loaded
-//! from other sources have the same type once constructed.
+//! Construct a [`CodeTheme`] with [`CodeTheme::builtin`], then select it with
+//! [`Options::code_theme`](crate::Options::code_theme). The renderer consults the theme when a
+//! fenced code block names a recognized language.
 
 use std::sync::LazyLock;
 
 use syntect::highlighting::{Theme, ThemeSet};
 
-/// A syntax-highlighting theme that is ready to render fenced code blocks.
+/// A syntax-highlighting theme for fenced code blocks.
 ///
 /// Construct a bundled theme with [`CodeTheme::builtin`], then pass it to
 /// [`Options::code_theme`](crate::Options::code_theme). The default is
 /// [`BuiltinCodeTheme::Base16OceanDark`].
 ///
+/// The renderer consults the theme only for fenced code blocks whose language is recognized.
+///
 /// This type hides the syntax-highlighting backend so applications do not need to depend on its
 /// types or version.
 #[derive(Clone, Debug)]
 pub struct CodeTheme {
-    source: ThemeSource,
-}
-
-#[derive(Clone, Debug)]
-enum ThemeSource {
-    Builtin(BuiltinCodeTheme),
+    theme: Theme,
 }
 
 impl CodeTheme {
-    /// Constructs a theme from one bundled with tui-markdown.
+    /// Selects a syntax-highlighting theme bundled with tui-markdown.
     #[must_use]
     pub fn builtin(theme: BuiltinCodeTheme) -> Self {
-        Self {
-            source: ThemeSource::Builtin(theme),
-        }
+        let theme = builtin_theme(theme).clone();
+        Self { theme }
     }
 }
 
@@ -44,8 +40,8 @@ impl Default for CodeTheme {
 
 /// A syntax-highlighting theme bundled with tui-markdown.
 ///
-/// Use this type to select a bundled theme, then construct a renderer-ready [`CodeTheme`] with
-/// [`CodeTheme::builtin`].
+/// Pass a variant to [`CodeTheme::builtin`] and select the resulting theme with
+/// [`Options::code_theme`](crate::Options::code_theme).
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BuiltinCodeTheme {
@@ -80,19 +76,15 @@ impl BuiltinCodeTheme {
     }
 }
 
-/// Resolves a public theme to the syntect theme used for highlighting.
-pub fn resolve(theme: &CodeTheme) -> &Theme {
-    match &theme.source {
-        ThemeSource::Builtin(theme) => builtin_theme(*theme),
+/// Resolves the configured theme or the shared default.
+///
+/// Calling this only after recognizing a fenced language avoids initializing the bundled theme set
+/// for ordinary Markdown and code fences that cannot be highlighted.
+pub fn theme_or_default(theme: Option<&CodeTheme>) -> &Theme {
+    match theme {
+        Some(theme) => &theme.theme,
+        None => default_theme(),
     }
-}
-
-/// Returns the unresolved default theme used until options are applied.
-pub fn default_code_theme() -> &'static CodeTheme {
-    static DEFAULT: CodeTheme = CodeTheme {
-        source: ThemeSource::Builtin(BuiltinCodeTheme::Base16OceanDark),
-    };
-    &DEFAULT
 }
 
 fn builtin_theme(theme: BuiltinCodeTheme) -> &'static Theme {
@@ -102,21 +94,15 @@ fn builtin_theme(theme: BuiltinCodeTheme) -> &'static Theme {
         .expect("every BuiltinCodeTheme variant must map to a bundled theme")
 }
 
+fn default_theme() -> &'static Theme {
+    builtin_theme(BuiltinCodeTheme::default())
+}
+
 static THEMES: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn ocean_dark_is_the_default() {
-        let default = CodeTheme::default();
-
-        assert!(matches!(
-            default.source,
-            ThemeSource::Builtin(BuiltinCodeTheme::Base16OceanDark)
-        ));
-    }
 
     #[test]
     fn every_builtin_theme_resolves() {
@@ -132,7 +118,7 @@ mod tests {
 
         for theme in themes {
             let theme = CodeTheme::builtin(theme);
-            let _ = resolve(&theme);
+            let _ = theme_or_default(Some(&theme));
         }
     }
 }

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -1,8 +1,8 @@
 //! Built-in syntax-highlighting themes for fenced code blocks.
 //!
-//! Construct a [`CodeTheme`] with [`CodeTheme::builtin`], then select it with
-//! [`Options::code_theme`](crate::Options::code_theme). The renderer consults the theme when a
-//! fenced code block names a recognized language.
+//! Pass a [`BuiltinCodeTheme`] to [`Options::code_theme`](crate::Options::code_theme), or convert it
+//! into an owned [`CodeTheme`]. The renderer consults the theme when a fenced code block names a
+//! recognized language.
 //!
 //! A configured [`CodeTheme`] owns its theme data. [`Options`](crate::Options) stores no theme by
 //! default; the renderer instead borrows the shared [`BuiltinCodeTheme::Base16OceanDark`] theme
@@ -14,7 +14,7 @@ use syntect::highlighting::{Theme, ThemeSet};
 
 /// An owned syntax-highlighting theme for fenced code blocks.
 ///
-/// Construct a bundled theme with [`CodeTheme::builtin`], then pass it to
+/// Convert a [`BuiltinCodeTheme`] into this type, or pass the built-in theme directly to
 /// [`Options::code_theme`](crate::Options::code_theme).
 ///
 /// The renderer consults the theme only for fenced code blocks whose language is recognized.
@@ -30,10 +30,8 @@ pub struct CodeTheme {
     theme: Theme,
 }
 
-impl CodeTheme {
-    /// Constructs an owned syntax-highlighting theme from a bundled theme.
-    #[must_use]
-    pub fn builtin(theme: BuiltinCodeTheme) -> Self {
+impl From<BuiltinCodeTheme> for CodeTheme {
+    fn from(theme: BuiltinCodeTheme) -> Self {
         let theme = builtin_theme(theme).clone();
         Self { theme }
     }
@@ -41,14 +39,14 @@ impl CodeTheme {
 
 impl Default for CodeTheme {
     fn default() -> Self {
-        Self::builtin(BuiltinCodeTheme::default())
+        BuiltinCodeTheme::default().into()
     }
 }
 
 /// A syntax-highlighting theme bundled with tui-markdown.
 ///
-/// Pass a variant to [`CodeTheme::builtin`] and select the resulting theme with
-/// [`Options::code_theme`](crate::Options::code_theme).
+/// Pass a variant directly to [`Options::code_theme`](crate::Options::code_theme), or convert it
+/// into an owned [`CodeTheme`].
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BuiltinCodeTheme {
@@ -125,14 +123,14 @@ mod tests {
         ];
 
         for theme in themes {
-            let theme = CodeTheme::builtin(theme);
+            let theme = CodeTheme::from(theme);
             let _ = theme_or_default(Some(&theme));
         }
     }
 
     #[test]
     fn configured_theme_is_borrowed_directly() {
-        let theme = CodeTheme::builtin(BuiltinCodeTheme::SolarizedDark);
+        let theme = CodeTheme::from(BuiltinCodeTheme::SolarizedDark);
 
         assert!(std::ptr::eq(theme_or_default(Some(&theme)), &theme.theme));
     }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -11,6 +11,10 @@
 //! Images render as `[img]` followed by their description, or by their destination when the
 //! description is empty. This is a text fallback; the crate does not load or render image
 //! resources.
+//!
+//! The default `highlight-code` feature highlights fenced code blocks whose language is recognized.
+//! Configure the built-in theme through [`Options`]; fences without a recognized language remain
+//! unhighlighted.
 #![cfg_attr(feature = "document-features", doc = "\n# Features")]
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 //! # Example
@@ -322,9 +326,11 @@ struct TextWriter<'a, 'theme, I, S: StyleSheet> {
     /// Active table builder that accumulates cells during table parsing.
     table_builder: Option<tables::TableBuilder<'a>>,
 
-    /// Theme to resolve when a fenced code block starts highlighting.
+    /// Explicit theme to use when a fenced code block starts highlighting.
+    ///
+    /// When absent, code highlighting resolves the shared built-in default.
     #[cfg(feature = "highlight-code")]
-    code_theme: &'theme CodeTheme,
+    code_theme: Option<&'theme CodeTheme>,
 
     /// Keeps the writer's shape consistent when syntax highlighting is disabled.
     #[cfg(not(feature = "highlight-code"))]
@@ -363,7 +369,7 @@ where
             in_definition_description: false,
             table_builder: None,
             #[cfg(feature = "highlight-code")]
-            code_theme: code_theme::default_code_theme(),
+            code_theme: None,
             #[cfg(not(feature = "highlight-code"))]
             code_theme_lifetime: std::marker::PhantomData,
         }
@@ -371,7 +377,7 @@ where
 
     /// Selects a configured theme before the event loop starts.
     #[cfg(feature = "highlight-code")]
-    fn set_code_theme(&mut self, theme: &'theme CodeTheme) {
+    fn set_code_theme(&mut self, theme: Option<&'theme CodeTheme>) {
         self.code_theme = theme;
     }
 
@@ -765,7 +771,7 @@ where
     fn set_code_highlighter(&mut self, lang: &str) {
         if let Some(syntax) = SYNTAX_SET.find_syntax_by_token(lang) {
             debug!("Starting code block with syntax: {:?}", lang);
-            let theme = code_theme::resolve(self.code_theme);
+            let theme = code_theme::theme_or_default(self.code_theme);
             let highlighter = HighlightLines::new(syntax, theme);
             self.code_highlighter = Some(highlighter);
         } else {
@@ -2648,6 +2654,21 @@ mod tests {
             let explicit = from_str_with_options(input, &options);
 
             assert_eq!(explicit, implicit);
+        }
+
+        #[rstest]
+        fn selected_theme_does_not_change_unrecognized_code(_with_tracing: DefaultGuard) {
+            let input = indoc! {"
+                ```not-a-language
+                some code
+                ```
+            "};
+            let default_out = from_str(input);
+            let theme = CodeTheme::builtin(BuiltinCodeTheme::InspiredGitHub);
+            let options = Options::default().code_theme(theme);
+            let selected_out = from_str_with_options(input, &options);
+
+            assert_eq!(selected_out, default_out);
         }
     }
 }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -765,7 +765,7 @@ where
     fn set_code_highlighter(&mut self, lang: &str) {
         if let Some(syntax) = SYNTAX_SET.find_syntax_by_token(lang) {
             debug!("Starting code block with syntax: {:?}", lang);
-            let theme = code_theme::backend_theme(self.code_theme);
+            let theme = code_theme::resolve(self.code_theme);
             let highlighter = HighlightLines::new(syntax, theme);
             self.code_highlighter = Some(highlighter);
         } else {

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -2635,8 +2635,7 @@ mod tests {
                 ```
             "};
             let default_out = from_str(input);
-            let theme = CodeTheme::builtin(BuiltinCodeTheme::InspiredGitHub);
-            let options = Options::default().code_theme(theme);
+            let options = Options::default().code_theme(BuiltinCodeTheme::InspiredGitHub);
             let custom_out = from_str_with_options(input, &options);
 
             assert_ne!(default_out, custom_out);
@@ -2664,8 +2663,7 @@ mod tests {
                 ```
             "};
             let default_out = from_str(input);
-            let theme = CodeTheme::builtin(BuiltinCodeTheme::InspiredGitHub);
-            let options = Options::default().code_theme(theme);
+            let options = Options::default().code_theme(BuiltinCodeTheme::InspiredGitHub);
             let selected_out = from_str_with_options(input, &options);
 
             assert_eq!(selected_out, default_out);

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -122,6 +122,15 @@ where
 /// Returns the names of all built-in syntax-highlighting themes.
 ///
 /// These names can be passed to [`Options::code_theme`].
+///
+/// # Example
+///
+/// ```
+/// use tui_markdown::{available_themes, Options};
+///
+/// assert!(available_themes().contains(&"InspiredGitHub"));
+/// let options = Options::default().code_theme("InspiredGitHub");
+/// ```
 #[cfg(feature = "highlight-code")]
 pub fn available_themes() -> Vec<&'static str> {
     THEME_SET.themes.keys().map(String::as_str).collect()
@@ -2622,12 +2631,18 @@ mod tests {
     }
 
     mod code_theme {
+        use pretty_assertions::assert_eq;
+
         use super::*;
 
         #[rstest]
-        fn invalid_theme_does_not_panic(_with_tracing: DefaultGuard) {
+        fn invalid_theme_falls_back_to_default(_with_tracing: DefaultGuard) {
+            let input = "```rust\nfn main() {}\n```";
+            let default_text = from_str(input);
             let options = Options::default().code_theme("nonexistent-theme");
-            let _text = from_str_with_options("```rust\nfn main() {}\n```", &options);
+            let fallback_text = from_str_with_options(input, &options);
+
+            assert_eq!(fallback_text, default_text);
         }
 
         #[rstest]
@@ -2636,7 +2651,7 @@ mod tests {
             let default_out = from_str("```rust\nfn main() {}\n```");
             let options = Options::default().code_theme("InspiredGitHub");
             let custom_out = from_str_with_options("```rust\nfn main() {}\n```", &options);
-            assert_ne!(format!("{default_out:?}"), format!("{custom_out:?}"));
+            assert_ne!(default_out, custom_out);
         }
 
         #[rstest]

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -54,15 +54,20 @@ use ratatui_core::text::{Line, Span, Text};
 #[cfg(feature = "highlight-code")]
 use syntect::{
     easy::HighlightLines,
-    highlighting::ThemeSet,
+    highlighting::Theme,
     parsing::SyntaxSet,
     util::{as_24_bit_terminal_escaped, LinesWithEndings},
 };
 use tracing::{debug, instrument, warn};
 
-pub use crate::options::{ImageFallback, Options};
+#[cfg(feature = "highlight-code")]
+#[doc(inline)]
+pub use crate::code_theme::available_themes;
+pub use crate::options::{ImageFallback, Options, DEFAULT_CODE_THEME};
 pub use crate::style_sheet::{AlertKind, DefaultStyleSheet, StyleSheet};
 
+#[cfg(feature = "highlight-code")]
+mod code_theme;
 mod options;
 mod style_sheet;
 mod tables;
@@ -109,31 +114,13 @@ where
     parse_opts.insert(ParseOptions::ENABLE_TABLES);
     let parser = Parser::new_ext(input, parse_opts);
 
-    let mut writer = TextWriter::new(
-        parser,
-        options.styles.clone(),
-        options.image_fallback,
-        options.code_theme.clone(),
-    );
+    let mut writer = TextWriter::new(parser, options.styles.clone(), options.image_fallback);
+    #[cfg(feature = "highlight-code")]
+    if let Some(theme_name) = options.selected_code_theme() {
+        writer.set_code_theme(theme_name);
+    }
     writer.run();
     writer.text
-}
-
-/// Returns the names of all built-in syntax-highlighting themes.
-///
-/// These names can be passed to [`Options::code_theme`].
-///
-/// # Example
-///
-/// ```
-/// use tui_markdown::{available_themes, Options};
-///
-/// assert!(available_themes().contains(&"InspiredGitHub"));
-/// let options = Options::default().code_theme("InspiredGitHub");
-/// ```
-#[cfg(feature = "highlight-code")]
-pub fn available_themes() -> Vec<&'static str> {
-    THEME_SET.themes.keys().map(String::as_str).collect()
 }
 
 // Heading attributes collected from pulldown-cmark to render after the heading text.
@@ -338,24 +325,22 @@ struct TextWriter<'a, I, S: StyleSheet> {
     /// Active table builder that accumulates cells during table parsing.
     table_builder: Option<tables::TableBuilder<'a>>,
 
-    /// Name of the syntect theme for code highlighting.
-    #[cfg_attr(not(feature = "highlight-code"), allow(dead_code))]
-    code_theme_name: String,
+    /// Resolved syntect theme used for code highlighting.
+    #[cfg(feature = "highlight-code")]
+    code_theme: &'static Theme,
 
     needs_newline: bool,
 }
 
 #[cfg(feature = "highlight-code")]
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
-#[cfg(feature = "highlight-code")]
-static THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
 
 impl<'a, I, S> TextWriter<'a, I, S>
 where
     I: Iterator<Item = Event<'a>>,
     S: StyleSheet,
 {
-    fn new(iter: I, styles: S, image_fallback: ImageFallback, code_theme_name: String) -> Self {
+    fn new(iter: I, styles: S, image_fallback: ImageFallback) -> Self {
         Self {
             iter,
             text: Text::default(),
@@ -376,8 +361,15 @@ where
             in_footnote_definition: false,
             in_definition_description: false,
             table_builder: None,
-            code_theme_name,
+            #[cfg(feature = "highlight-code")]
+            code_theme: code_theme::default_theme(),
         }
+    }
+
+    /// Resolves a configured theme before the event loop starts.
+    #[cfg(feature = "highlight-code")]
+    fn set_code_theme(&mut self, theme_name: &str) {
+        self.code_theme = code_theme::resolve(theme_name);
     }
 
     fn run(&mut self) {
@@ -770,18 +762,7 @@ where
     fn set_code_highlighter(&mut self, lang: &str) {
         if let Some(syntax) = SYNTAX_SET.find_syntax_by_token(lang) {
             debug!("Starting code block with syntax: {:?}", lang);
-            let theme = THEME_SET
-                .themes
-                .get(&self.code_theme_name)
-                .unwrap_or_else(|| {
-                    warn!(
-                        "Theme {:?} not found, falling back to {:?}",
-                        self.code_theme_name,
-                        Options::<DefaultStyleSheet>::DEFAULT_CODE_THEME,
-                    );
-                    &THEME_SET.themes[Options::<DefaultStyleSheet>::DEFAULT_CODE_THEME]
-                });
-            let highlighter = HighlightLines::new(syntax, theme);
+            let highlighter = HighlightLines::new(syntax, self.code_theme);
             self.code_highlighter = Some(highlighter);
         } else {
             warn!("Could not find syntax for code block: {:?}", lang);
@@ -2637,7 +2618,11 @@ mod tests {
 
         #[rstest]
         fn invalid_theme_falls_back_to_default(_with_tracing: DefaultGuard) {
-            let input = "```rust\nfn main() {}\n```";
+            let input = indoc! {"
+                ```rust
+                fn main() {}
+                ```
+            "};
             let default_text = from_str(input);
             let options = Options::default().code_theme("nonexistent-theme");
             let fallback_text = from_str_with_options(input, &options);
@@ -2648,18 +2633,31 @@ mod tests {
         #[rstest]
         #[cfg(feature = "highlight-code")]
         fn different_theme_produces_different_output(_with_tracing: DefaultGuard) {
-            let default_out = from_str("```rust\nfn main() {}\n```");
+            let input = indoc! {"
+                ```rust
+                fn main() {}
+                ```
+            "};
+            let default_out = from_str(input);
             let options = Options::default().code_theme("InspiredGitHub");
-            let custom_out = from_str_with_options("```rust\nfn main() {}\n```", &options);
+            let custom_out = from_str_with_options(input, &options);
+
             assert_ne!(default_out, custom_out);
         }
 
         #[rstest]
         #[cfg(feature = "highlight-code")]
-        fn available_themes_not_empty(_with_tracing: DefaultGuard) {
-            let themes = crate::available_themes();
-            assert!(!themes.is_empty());
-            assert!(themes.contains(&"base16-ocean.dark"));
+        fn explicit_default_theme_matches_implicit_default(_with_tracing: DefaultGuard) {
+            let input = indoc! {"
+                ```rust
+                fn main() {}
+                ```
+            "};
+            let implicit = from_str(input);
+            let options = Options::default().code_theme(DEFAULT_CODE_THEME);
+            let explicit = from_str_with_options(input, &options);
+
+            assert_eq!(explicit, implicit);
         }
     }
 }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -54,7 +54,6 @@ use ratatui_core::text::{Line, Span, Text};
 #[cfg(feature = "highlight-code")]
 use syntect::{
     easy::HighlightLines,
-    highlighting::Theme,
     parsing::SyntaxSet,
     util::{as_24_bit_terminal_escaped, LinesWithEndings},
 };
@@ -323,9 +322,9 @@ struct TextWriter<'a, 'theme, I, S: StyleSheet> {
     /// Active table builder that accumulates cells during table parsing.
     table_builder: Option<tables::TableBuilder<'a>>,
 
-    /// Resolved syntect theme used for code highlighting.
+    /// Theme to resolve when a fenced code block starts highlighting.
     #[cfg(feature = "highlight-code")]
-    code_theme: &'theme Theme,
+    code_theme: &'theme CodeTheme,
 
     /// Keeps the writer's shape consistent when syntax highlighting is disabled.
     #[cfg(not(feature = "highlight-code"))]
@@ -364,7 +363,7 @@ where
             in_definition_description: false,
             table_builder: None,
             #[cfg(feature = "highlight-code")]
-            code_theme: code_theme::default_backend_theme(),
+            code_theme: code_theme::default_code_theme(),
             #[cfg(not(feature = "highlight-code"))]
             code_theme_lifetime: std::marker::PhantomData,
         }
@@ -373,7 +372,7 @@ where
     /// Selects a configured theme before the event loop starts.
     #[cfg(feature = "highlight-code")]
     fn set_code_theme(&mut self, theme: &'theme CodeTheme) {
-        self.code_theme = code_theme::backend_theme(theme);
+        self.code_theme = theme;
     }
 
     fn run(&mut self) {
@@ -766,7 +765,8 @@ where
     fn set_code_highlighter(&mut self, lang: &str) {
         if let Some(syntax) = SYNTAX_SET.find_syntax_by_token(lang) {
             debug!("Starting code block with syntax: {:?}", lang);
-            let highlighter = HighlightLines::new(syntax, self.code_theme);
+            let theme = code_theme::backend_theme(self.code_theme);
+            let highlighter = HighlightLines::new(syntax, theme);
             self.code_highlighter = Some(highlighter);
         } else {
             warn!("Could not find syntax for code block: {:?}", lang);

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -12,9 +12,9 @@
 //! description is empty. This is a text fallback; the crate does not load or render image
 //! resources.
 //!
-//! The default `highlight-code` feature highlights fenced code blocks whose language is recognized.
-//! Configure the built-in theme through [`Options`]; fences without a recognized language remain
-//! unhighlighted.
+//! The default `highlight-code` feature highlights fenced code blocks whose language is recognized,
+//! using `Base16OceanDark` unless [`Options`] selects another built-in theme.
+//! Fences without a recognized language remain unhighlighted.
 #![cfg_attr(feature = "document-features", doc = "\n# Features")]
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 //! # Example

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -109,9 +109,22 @@ where
     parse_opts.insert(ParseOptions::ENABLE_TABLES);
     let parser = Parser::new_ext(input, parse_opts);
 
-    let mut writer = TextWriter::new(parser, options.styles.clone(), options.image_fallback);
+    let mut writer = TextWriter::new(
+        parser,
+        options.styles.clone(),
+        options.image_fallback,
+        options.code_theme.clone(),
+    );
     writer.run();
     writer.text
+}
+
+/// Returns the names of all built-in syntax-highlighting themes.
+///
+/// These names can be passed to [`Options::code_theme`].
+#[cfg(feature = "highlight-code")]
+pub fn available_themes() -> Vec<&'static str> {
+    THEME_SET.themes.keys().map(String::as_str).collect()
 }
 
 // Heading attributes collected from pulldown-cmark to render after the heading text.
@@ -316,6 +329,10 @@ struct TextWriter<'a, I, S: StyleSheet> {
     /// Active table builder that accumulates cells during table parsing.
     table_builder: Option<tables::TableBuilder<'a>>,
 
+    /// Name of the syntect theme for code highlighting.
+    #[cfg_attr(not(feature = "highlight-code"), allow(dead_code))]
+    code_theme_name: String,
+
     needs_newline: bool,
 }
 
@@ -329,7 +346,7 @@ where
     I: Iterator<Item = Event<'a>>,
     S: StyleSheet,
 {
-    fn new(iter: I, styles: S, image_fallback: ImageFallback) -> Self {
+    fn new(iter: I, styles: S, image_fallback: ImageFallback, code_theme_name: String) -> Self {
         Self {
             iter,
             text: Text::default(),
@@ -350,6 +367,7 @@ where
             in_footnote_definition: false,
             in_definition_description: false,
             table_builder: None,
+            code_theme_name,
         }
     }
 
@@ -743,7 +761,17 @@ where
     fn set_code_highlighter(&mut self, lang: &str) {
         if let Some(syntax) = SYNTAX_SET.find_syntax_by_token(lang) {
             debug!("Starting code block with syntax: {:?}", lang);
-            let theme = &THEME_SET.themes["base16-ocean.dark"];
+            let theme = THEME_SET
+                .themes
+                .get(&self.code_theme_name)
+                .unwrap_or_else(|| {
+                    warn!(
+                        "Theme {:?} not found, falling back to {:?}",
+                        self.code_theme_name,
+                        Options::<DefaultStyleSheet>::DEFAULT_CODE_THEME,
+                    );
+                    &THEME_SET.themes[Options::<DefaultStyleSheet>::DEFAULT_CODE_THEME]
+                });
             let highlighter = HighlightLines::new(syntax, theme);
             self.code_highlighter = Some(highlighter);
         } else {
@@ -2590,6 +2618,33 @@ mod tests {
                     Span::raw(" after"),
                 ]))
             );
+        }
+    }
+
+    mod code_theme {
+        use super::*;
+
+        #[rstest]
+        fn invalid_theme_does_not_panic(_with_tracing: DefaultGuard) {
+            let options = Options::default().code_theme("nonexistent-theme");
+            let _text = from_str_with_options("```rust\nfn main() {}\n```", &options);
+        }
+
+        #[rstest]
+        #[cfg(feature = "highlight-code")]
+        fn different_theme_produces_different_output(_with_tracing: DefaultGuard) {
+            let default_out = from_str("```rust\nfn main() {}\n```");
+            let options = Options::default().code_theme("InspiredGitHub");
+            let custom_out = from_str_with_options("```rust\nfn main() {}\n```", &options);
+            assert_ne!(format!("{default_out:?}"), format!("{custom_out:?}"));
+        }
+
+        #[rstest]
+        #[cfg(feature = "highlight-code")]
+        fn available_themes_not_empty(_with_tracing: DefaultGuard) {
+            let themes = crate::available_themes();
+            assert!(!themes.is_empty());
+            assert!(themes.contains(&"base16-ocean.dark"));
         }
     }
 }

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -60,10 +60,10 @@ use syntect::{
 };
 use tracing::{debug, instrument, warn};
 
-#[cfg(feature = "highlight-code")]
 #[doc(inline)]
-pub use crate::code_theme::available_themes;
-pub use crate::options::{ImageFallback, Options, DEFAULT_CODE_THEME};
+#[cfg(feature = "highlight-code")]
+pub use crate::code_theme::{BuiltinCodeTheme, CodeTheme};
+pub use crate::options::{ImageFallback, Options};
 pub use crate::style_sheet::{AlertKind, DefaultStyleSheet, StyleSheet};
 
 #[cfg(feature = "highlight-code")]
@@ -116,9 +116,7 @@ where
 
     let mut writer = TextWriter::new(parser, options.styles.clone(), options.image_fallback);
     #[cfg(feature = "highlight-code")]
-    if let Some(theme_name) = options.selected_code_theme() {
-        writer.set_code_theme(theme_name);
-    }
+    writer.set_code_theme(options.selected_code_theme());
     writer.run();
     writer.text
 }
@@ -270,7 +268,7 @@ impl<'a> PendingImage<'a> {
     }
 }
 
-struct TextWriter<'a, I, S: StyleSheet> {
+struct TextWriter<'a, 'theme, I, S: StyleSheet> {
     /// Iterator supplying events.
     iter: I,
 
@@ -290,7 +288,7 @@ struct TextWriter<'a, I, S: StyleSheet> {
 
     /// Used to highlight code blocks, set when  a codeblock is encountered
     #[cfg(feature = "highlight-code")]
-    code_highlighter: Option<HighlightLines<'a>>,
+    code_highlighter: Option<HighlightLines<'theme>>,
 
     /// Current list index as a stack of indices.
     list_indices: Vec<Option<u64>>,
@@ -327,7 +325,11 @@ struct TextWriter<'a, I, S: StyleSheet> {
 
     /// Resolved syntect theme used for code highlighting.
     #[cfg(feature = "highlight-code")]
-    code_theme: &'static Theme,
+    code_theme: &'theme Theme,
+
+    /// Keeps the writer's shape consistent when syntax highlighting is disabled.
+    #[cfg(not(feature = "highlight-code"))]
+    code_theme_lifetime: std::marker::PhantomData<&'theme ()>,
 
     needs_newline: bool,
 }
@@ -335,7 +337,7 @@ struct TextWriter<'a, I, S: StyleSheet> {
 #[cfg(feature = "highlight-code")]
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
 
-impl<'a, I, S> TextWriter<'a, I, S>
+impl<'a, 'theme, I, S> TextWriter<'a, 'theme, I, S>
 where
     I: Iterator<Item = Event<'a>>,
     S: StyleSheet,
@@ -362,14 +364,16 @@ where
             in_definition_description: false,
             table_builder: None,
             #[cfg(feature = "highlight-code")]
-            code_theme: code_theme::default_theme(),
+            code_theme: code_theme::default_backend_theme(),
+            #[cfg(not(feature = "highlight-code"))]
+            code_theme_lifetime: std::marker::PhantomData,
         }
     }
 
-    /// Resolves a configured theme before the event loop starts.
+    /// Selects a configured theme before the event loop starts.
     #[cfg(feature = "highlight-code")]
-    fn set_code_theme(&mut self, theme_name: &str) {
-        self.code_theme = code_theme::resolve(theme_name);
+    fn set_code_theme(&mut self, theme: &'theme CodeTheme) {
+        self.code_theme = code_theme::backend_theme(theme);
     }
 
     fn run(&mut self) {
@@ -2611,27 +2615,13 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "highlight-code")]
     mod code_theme {
         use pretty_assertions::assert_eq;
 
         use super::*;
 
         #[rstest]
-        fn invalid_theme_falls_back_to_default(_with_tracing: DefaultGuard) {
-            let input = indoc! {"
-                ```rust
-                fn main() {}
-                ```
-            "};
-            let default_text = from_str(input);
-            let options = Options::default().code_theme("nonexistent-theme");
-            let fallback_text = from_str_with_options(input, &options);
-
-            assert_eq!(fallback_text, default_text);
-        }
-
-        #[rstest]
-        #[cfg(feature = "highlight-code")]
         fn different_theme_produces_different_output(_with_tracing: DefaultGuard) {
             let input = indoc! {"
                 ```rust
@@ -2639,14 +2629,14 @@ mod tests {
                 ```
             "};
             let default_out = from_str(input);
-            let options = Options::default().code_theme("InspiredGitHub");
+            let theme = CodeTheme::builtin(BuiltinCodeTheme::InspiredGitHub);
+            let options = Options::default().code_theme(theme);
             let custom_out = from_str_with_options(input, &options);
 
             assert_ne!(default_out, custom_out);
         }
 
         #[rstest]
-        #[cfg(feature = "highlight-code")]
         fn explicit_default_theme_matches_implicit_default(_with_tracing: DefaultGuard) {
             let input = indoc! {"
                 ```rust
@@ -2654,7 +2644,7 @@ mod tests {
                 ```
             "};
             let implicit = from_str(input);
-            let options = Options::default().code_theme(DEFAULT_CODE_THEME);
+            let options = Options::default().code_theme(CodeTheme::default());
             let explicit = from_str_with_options(input, &options);
 
             assert_eq!(explicit, implicit);

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -771,7 +771,11 @@ where
     fn set_code_highlighter(&mut self, lang: &str) {
         if let Some(syntax) = SYNTAX_SET.find_syntax_by_token(lang) {
             debug!("Starting code block with syntax: {:?}", lang);
-            let theme = code_theme::theme_or_default(self.code_theme);
+            let code_theme = match self.code_theme {
+                Some(code_theme) => code_theme,
+                None => code_theme::default(),
+            };
+            let theme = code_theme::theme(code_theme);
             let highlighter = HighlightLines::new(syntax, theme);
             self.code_highlighter = Some(highlighter);
         } else {
@@ -2649,7 +2653,7 @@ mod tests {
                 ```
             "};
             let implicit = from_str(input);
-            let options = Options::default().code_theme(CodeTheme::default());
+            let options = Options::default().code_theme(BuiltinCodeTheme::default());
             let explicit = from_str_with_options(input, &options);
 
             assert_eq!(explicit, implicit);

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -4,12 +4,9 @@
 //! theme. [`Options`] is non-exhaustive, allowing new rendering choices to be added without
 //! breaking existing code.
 
+#[cfg(feature = "highlight-code")]
+use crate::CodeTheme;
 use crate::{DefaultStyleSheet, StyleSheet};
-
-/// Name of the built-in syntax-highlighting theme used by default.
-///
-/// This constant identifies a syntect theme when the `highlight-code` feature is enabled.
-pub const DEFAULT_CODE_THEME: &str = "base16-ocean.dark";
 
 /// Text used to represent Markdown images in rendered terminal output.
 ///
@@ -52,6 +49,7 @@ pub enum ImageFallback {
 ///
 /// ```
 /// use tui_markdown::Options;
+///
 /// let options = Options::default();
 ///
 /// // or with a custom style sheet
@@ -88,7 +86,7 @@ pub enum ImageFallback {
 ///     }
 /// }
 ///
-/// let options = Options::new(MyStyleSheet).code_theme("Solarized (dark)");
+/// let options = Options::new(MyStyleSheet);
 /// ```
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -98,11 +96,9 @@ pub struct Options<S: StyleSheet = DefaultStyleSheet> {
     pub(crate) styles: S,
     /// The content to render in place of images.
     pub(crate) image_fallback: ImageFallback,
-    /// Name of the selected syntect theme for syntax-highlighted code blocks.
-    ///
-    /// `None` uses [`DEFAULT_CODE_THEME`]. When the `highlight-code` feature is disabled this
-    /// field has no effect.
-    code_theme: Option<String>,
+    /// Syntax-highlighting theme for fenced code blocks.
+    #[cfg(feature = "highlight-code")]
+    code_theme: CodeTheme,
 }
 
 impl<S: StyleSheet> Options<S> {
@@ -111,7 +107,8 @@ impl<S: StyleSheet> Options<S> {
         Self {
             styles,
             image_fallback: ImageFallback::default(),
-            code_theme: None,
+            #[cfg(feature = "highlight-code")]
+            code_theme: CodeTheme::default(),
         }
     }
 
@@ -124,24 +121,32 @@ impl<S: StyleSheet> Options<S> {
         self
     }
 
-    /// Sets the syntax-highlighting theme by name.
+    /// Selects the syntax-highlighting theme for fenced code blocks.
     ///
-    /// The name must match a theme returned by [`crate::available_themes`]. Invalid names fall back
-    /// to [`DEFAULT_CODE_THEME`] when a code block is rendered.
+    /// The theme's origin is not significant here. Construct a bundled theme with
+    /// [`CodeTheme::builtin`](crate::CodeTheme::builtin), or use another `CodeTheme` constructor
+    /// provided by an enabled feature.
     ///
-    /// This setting has no effect when the `highlight-code` feature is disabled.
+    /// # Example
+    ///
+    /// ```
+    /// use tui_markdown::{BuiltinCodeTheme, CodeTheme, Options};
+    ///
+    /// let theme = CodeTheme::builtin(BuiltinCodeTheme::SolarizedDark);
+    /// let options = Options::default().code_theme(theme);
+    /// ```
+    #[cfg(feature = "highlight-code")]
     #[must_use]
-    pub fn code_theme(mut self, theme_name: impl Into<String>) -> Self {
-        self.code_theme = Some(theme_name.into());
+    pub fn code_theme(mut self, code_theme: CodeTheme) -> Self {
+        self.code_theme = code_theme;
         self
     }
 
-    /// Returns the explicitly selected syntax-highlighting theme name.
-    ///
-    /// `None` means code blocks use [`DEFAULT_CODE_THEME`].
+    /// Returns the syntax-highlighting theme used for fenced code blocks.
+    #[cfg(feature = "highlight-code")]
     #[must_use]
-    pub fn selected_code_theme(&self) -> Option<&str> {
-        self.code_theme.as_deref()
+    pub fn selected_code_theme(&self) -> &CodeTheme {
+        &self.code_theme
     }
 }
 
@@ -203,7 +208,8 @@ mod tests {
         let options = Options {
             styles: CustomStyleSheet,
             image_fallback: ImageFallback::default(),
-            code_theme: None,
+            #[cfg(feature = "highlight-code")]
+            code_theme: CodeTheme::default(),
         };
 
         assert_eq!(options.styles.heading(1), Style::new().red().bold());
@@ -231,16 +237,19 @@ mod tests {
     }
 
     #[test]
-    fn code_theme_is_opt_in() {
+    #[cfg(feature = "highlight-code")]
+    fn code_theme_has_a_default() {
         let options: Options = Options::default();
 
-        assert_eq!(options.selected_code_theme(), None);
+        assert_eq!(options.selected_code_theme(), &CodeTheme::default());
     }
 
     #[test]
-    fn code_theme_selects_a_name() {
-        let options = Options::default().code_theme("Solarized (dark)");
+    #[cfg(feature = "highlight-code")]
+    fn code_theme_selects_theme() {
+        let theme = CodeTheme::builtin(crate::BuiltinCodeTheme::SolarizedDark);
+        let options = Options::default().code_theme(theme.clone());
 
-        assert_eq!(options.selected_code_theme(), Some("Solarized (dark)"));
+        assert_eq!(options.selected_code_theme(), &theme);
     }
 }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -127,6 +127,7 @@ impl<S: StyleSheet> Options<S> {
     /// to [`Self::DEFAULT_CODE_THEME`] when a code block is rendered.
     ///
     /// This setting has no effect when the `highlight-code` feature is disabled.
+    #[must_use]
     pub fn code_theme(mut self, theme_name: impl Into<String>) -> Self {
         self.code_theme = theme_name.into();
         self

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -125,7 +125,8 @@ impl<S: StyleSheet> Options<S> {
 
     /// Selects the syntax-highlighting theme for fenced code blocks.
     ///
-    /// The default is [`Base16OceanDark`](crate::BuiltinCodeTheme::Base16OceanDark).
+    /// By default, no explicit theme is stored and the renderer borrows its shared
+    /// [`Base16OceanDark`](crate::BuiltinCodeTheme::Base16OceanDark) theme.
     /// The selected theme applies when a fenced code block names a recognized language.
     ///
     /// # Example

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -1,7 +1,8 @@
 //! Rendering configuration for tui-markdown.
 //!
-//! Options control the renderer's style sheet and image fallback content. [`Options`] is
-//! non-exhaustive, allowing new rendering choices to be added without breaking existing code.
+//! Options control the renderer's style sheet, image fallback content, and syntax-highlighting
+//! theme. [`Options`] is non-exhaustive, allowing new rendering choices to be added without
+//! breaking existing code.
 
 use crate::{DefaultStyleSheet, StyleSheet};
 
@@ -82,7 +83,7 @@ pub enum ImageFallback {
 ///     }
 /// }
 ///
-/// let options = Options::new(MyStyleSheet);
+/// let options = Options::new(MyStyleSheet).code_theme("Solarized (dark)");
 /// ```
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -92,14 +93,22 @@ pub struct Options<S: StyleSheet = DefaultStyleSheet> {
     pub(crate) styles: S,
     /// The content to render in place of images.
     pub(crate) image_fallback: ImageFallback,
+    /// Name of the syntect theme used for syntax-highlighted code blocks.
+    ///
+    /// When the `highlight-code` feature is disabled this field has no effect.
+    pub(crate) code_theme: String,
 }
 
 impl<S: StyleSheet> Options<S> {
+    /// The default syntax-highlighting theme name.
+    pub const DEFAULT_CODE_THEME: &str = "base16-ocean.dark";
+
     /// Creates a new `Options` instance with the provided style sheet.
     pub fn new(styles: S) -> Self {
         Self {
             styles,
             image_fallback: ImageFallback::default(),
+            code_theme: Self::DEFAULT_CODE_THEME.to_owned(),
         }
     }
 
@@ -109,6 +118,17 @@ impl<S: StyleSheet> Options<S> {
     #[must_use]
     pub fn image_fallback(mut self, image_fallback: ImageFallback) -> Self {
         self.image_fallback = image_fallback;
+        self
+    }
+
+    /// Sets the syntax-highlighting theme by name.
+    ///
+    /// The name must match a theme returned by [`crate::available_themes`]. Invalid names fall back
+    /// to [`Self::DEFAULT_CODE_THEME`] when a code block is rendered.
+    ///
+    /// This setting has no effect when the `highlight-code` feature is disabled.
+    pub fn code_theme(mut self, theme_name: impl Into<String>) -> Self {
+        self.code_theme = theme_name.into();
         self
     }
 }
@@ -171,6 +191,7 @@ mod tests {
         let options = Options {
             styles: CustomStyleSheet,
             image_fallback: ImageFallback::default(),
+            code_theme: Options::<CustomStyleSheet>::DEFAULT_CODE_THEME.to_owned(),
         };
 
         assert_eq!(options.styles.heading(1), Style::new().red().bold());
@@ -195,5 +216,22 @@ mod tests {
         let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
 
         assert_eq!(options.image_fallback, ImageFallback::AltTextAndUrl);
+    }
+
+    #[test]
+    fn default_code_theme() {
+        let options: Options = Options::default();
+
+        assert_eq!(
+            options.code_theme,
+            Options::<DefaultStyleSheet>::DEFAULT_CODE_THEME
+        );
+    }
+
+    #[test]
+    fn custom_code_theme() {
+        let options = Options::default().code_theme("Solarized (dark)");
+
+        assert_eq!(options.code_theme, "Solarized (dark)");
     }
 }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -127,20 +127,21 @@ impl<S: StyleSheet> Options<S> {
     ///
     /// By default, no explicit theme is stored and the renderer borrows its shared
     /// [`Base16OceanDark`](crate::BuiltinCodeTheme::Base16OceanDark) theme.
-    /// The selected theme applies when a fenced code block names a recognized language.
+    /// Pass a [`BuiltinCodeTheme`](crate::BuiltinCodeTheme) directly, or pass an owned
+    /// [`CodeTheme`] constructed by another theme source. The selected theme applies when a fenced
+    /// code block names a recognized language.
     ///
     /// # Example
     ///
     /// ```
-    /// use tui_markdown::{BuiltinCodeTheme, CodeTheme, Options};
+    /// use tui_markdown::{BuiltinCodeTheme, Options};
     ///
-    /// let theme = CodeTheme::builtin(BuiltinCodeTheme::SolarizedDark);
-    /// let options = Options::default().code_theme(theme);
+    /// let options = Options::default().code_theme(BuiltinCodeTheme::SolarizedDark);
     /// ```
     #[cfg(feature = "highlight-code")]
     #[must_use]
-    pub fn code_theme(mut self, code_theme: CodeTheme) -> Self {
-        self.code_theme = Some(code_theme);
+    pub fn code_theme(mut self, code_theme: impl Into<CodeTheme>) -> Self {
+        self.code_theme = Some(code_theme.into());
         self
     }
 
@@ -252,8 +253,7 @@ mod tests {
     #[test]
     #[cfg(feature = "highlight-code")]
     fn code_theme_selects_theme() {
-        let theme = CodeTheme::builtin(crate::BuiltinCodeTheme::SolarizedDark);
-        let options = Options::default().code_theme(theme);
+        let options = Options::default().code_theme(crate::BuiltinCodeTheme::SolarizedDark);
 
         assert!(options.selected_code_theme().is_some());
     }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -241,7 +241,10 @@ mod tests {
     fn code_theme_has_a_default() {
         let options: Options = Options::default();
 
-        assert_eq!(options.selected_code_theme(), &CodeTheme::default());
+        assert!(std::ptr::eq(
+            crate::code_theme::backend_theme(options.selected_code_theme()),
+            crate::code_theme::default_backend_theme()
+        ));
     }
 
     #[test]
@@ -250,6 +253,9 @@ mod tests {
         let theme = CodeTheme::builtin(crate::BuiltinCodeTheme::SolarizedDark);
         let options = Options::default().code_theme(theme.clone());
 
-        assert_eq!(options.selected_code_theme(), &theme);
+        assert!(std::ptr::eq(
+            crate::code_theme::backend_theme(options.selected_code_theme()),
+            crate::code_theme::backend_theme(&theme)
+        ));
     }
 }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -96,9 +96,11 @@ pub struct Options<S: StyleSheet = DefaultStyleSheet> {
     pub(crate) styles: S,
     /// The content to render in place of images.
     pub(crate) image_fallback: ImageFallback,
-    /// Syntax-highlighting theme for fenced code blocks.
+    /// Explicit syntax-highlighting theme for fenced code blocks.
+    ///
+    /// When absent, the renderer uses the shared built-in default.
     #[cfg(feature = "highlight-code")]
-    code_theme: CodeTheme,
+    code_theme: Option<CodeTheme>,
 }
 
 impl<S: StyleSheet> Options<S> {
@@ -108,7 +110,7 @@ impl<S: StyleSheet> Options<S> {
             styles,
             image_fallback: ImageFallback::default(),
             #[cfg(feature = "highlight-code")]
-            code_theme: CodeTheme::default(),
+            code_theme: None,
         }
     }
 
@@ -123,9 +125,8 @@ impl<S: StyleSheet> Options<S> {
 
     /// Selects the syntax-highlighting theme for fenced code blocks.
     ///
-    /// The theme's origin is not significant here. Construct a bundled theme with
-    /// [`CodeTheme::builtin`](crate::CodeTheme::builtin), or use another `CodeTheme` constructor
-    /// provided by an enabled feature.
+    /// The default is [`Base16OceanDark`](crate::BuiltinCodeTheme::Base16OceanDark).
+    /// The selected theme applies when a fenced code block names a recognized language.
     ///
     /// # Example
     ///
@@ -138,15 +139,18 @@ impl<S: StyleSheet> Options<S> {
     #[cfg(feature = "highlight-code")]
     #[must_use]
     pub fn code_theme(mut self, code_theme: CodeTheme) -> Self {
-        self.code_theme = code_theme;
+        self.code_theme = Some(code_theme);
         self
     }
 
-    /// Returns the syntax-highlighting theme used for fenced code blocks.
+    /// Returns the explicitly configured syntax-highlighting theme.
+    ///
+    /// Returns `None` when the renderer will use the shared
+    /// [`Base16OceanDark`](crate::BuiltinCodeTheme::Base16OceanDark) default.
     #[cfg(feature = "highlight-code")]
     #[must_use]
-    pub fn selected_code_theme(&self) -> &CodeTheme {
-        &self.code_theme
+    pub fn selected_code_theme(&self) -> Option<&CodeTheme> {
+        self.code_theme.as_ref()
     }
 }
 
@@ -209,7 +213,7 @@ mod tests {
             styles: CustomStyleSheet,
             image_fallback: ImageFallback::default(),
             #[cfg(feature = "highlight-code")]
-            code_theme: CodeTheme::default(),
+            code_theme: None,
         };
 
         assert_eq!(options.styles.heading(1), Style::new().red().bold());
@@ -238,24 +242,18 @@ mod tests {
 
     #[test]
     #[cfg(feature = "highlight-code")]
-    fn code_theme_has_a_default() {
+    fn default_has_no_explicit_code_theme() {
         let options: Options = Options::default();
 
-        let selected = crate::code_theme::resolve(options.selected_code_theme());
-        let default = CodeTheme::default();
-        let expected = crate::code_theme::resolve(&default);
-        assert!(std::ptr::eq(selected, expected));
+        assert!(options.selected_code_theme().is_none());
     }
 
     #[test]
     #[cfg(feature = "highlight-code")]
     fn code_theme_selects_theme() {
         let theme = CodeTheme::builtin(crate::BuiltinCodeTheme::SolarizedDark);
-        let options = Options::default().code_theme(theme.clone());
+        let options = Options::default().code_theme(theme);
 
-        assert!(std::ptr::eq(
-            crate::code_theme::resolve(options.selected_code_theme()),
-            crate::code_theme::resolve(&theme)
-        ));
+        assert!(options.selected_code_theme().is_some());
     }
 }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -6,6 +6,11 @@
 
 use crate::{DefaultStyleSheet, StyleSheet};
 
+/// Name of the built-in syntax-highlighting theme used by default.
+///
+/// This constant identifies a syntect theme when the `highlight-code` feature is enabled.
+pub const DEFAULT_CODE_THEME: &str = "base16-ocean.dark";
+
 /// Text used to represent Markdown images in rendered terminal output.
 ///
 /// This option does not load or render image resources. It controls whether the text fallback
@@ -93,22 +98,20 @@ pub struct Options<S: StyleSheet = DefaultStyleSheet> {
     pub(crate) styles: S,
     /// The content to render in place of images.
     pub(crate) image_fallback: ImageFallback,
-    /// Name of the syntect theme used for syntax-highlighted code blocks.
+    /// Name of the selected syntect theme for syntax-highlighted code blocks.
     ///
-    /// When the `highlight-code` feature is disabled this field has no effect.
-    pub(crate) code_theme: String,
+    /// `None` uses [`DEFAULT_CODE_THEME`]. When the `highlight-code` feature is disabled this
+    /// field has no effect.
+    code_theme: Option<String>,
 }
 
 impl<S: StyleSheet> Options<S> {
-    /// The default syntax-highlighting theme name.
-    pub const DEFAULT_CODE_THEME: &str = "base16-ocean.dark";
-
     /// Creates a new `Options` instance with the provided style sheet.
     pub fn new(styles: S) -> Self {
         Self {
             styles,
             image_fallback: ImageFallback::default(),
-            code_theme: Self::DEFAULT_CODE_THEME.to_owned(),
+            code_theme: None,
         }
     }
 
@@ -124,13 +127,21 @@ impl<S: StyleSheet> Options<S> {
     /// Sets the syntax-highlighting theme by name.
     ///
     /// The name must match a theme returned by [`crate::available_themes`]. Invalid names fall back
-    /// to [`Self::DEFAULT_CODE_THEME`] when a code block is rendered.
+    /// to [`DEFAULT_CODE_THEME`] when a code block is rendered.
     ///
     /// This setting has no effect when the `highlight-code` feature is disabled.
     #[must_use]
     pub fn code_theme(mut self, theme_name: impl Into<String>) -> Self {
-        self.code_theme = theme_name.into();
+        self.code_theme = Some(theme_name.into());
         self
+    }
+
+    /// Returns the explicitly selected syntax-highlighting theme name.
+    ///
+    /// `None` means code blocks use [`DEFAULT_CODE_THEME`].
+    #[must_use]
+    pub fn selected_code_theme(&self) -> Option<&str> {
+        self.code_theme.as_deref()
     }
 }
 
@@ -192,7 +203,7 @@ mod tests {
         let options = Options {
             styles: CustomStyleSheet,
             image_fallback: ImageFallback::default(),
-            code_theme: Options::<CustomStyleSheet>::DEFAULT_CODE_THEME.to_owned(),
+            code_theme: None,
         };
 
         assert_eq!(options.styles.heading(1), Style::new().red().bold());
@@ -220,19 +231,16 @@ mod tests {
     }
 
     #[test]
-    fn default_code_theme() {
+    fn code_theme_is_opt_in() {
         let options: Options = Options::default();
 
-        assert_eq!(
-            options.code_theme,
-            Options::<DefaultStyleSheet>::DEFAULT_CODE_THEME
-        );
+        assert_eq!(options.selected_code_theme(), None);
     }
 
     #[test]
-    fn custom_code_theme() {
+    fn code_theme_selects_a_name() {
         let options = Options::default().code_theme("Solarized (dark)");
 
-        assert_eq!(options.code_theme, "Solarized (dark)");
+        assert_eq!(options.selected_code_theme(), Some("Solarized (dark)"));
     }
 }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -241,9 +241,9 @@ mod tests {
     fn code_theme_has_a_default() {
         let options: Options = Options::default();
 
-        let selected = crate::code_theme::backend_theme(options.selected_code_theme());
+        let selected = crate::code_theme::resolve(options.selected_code_theme());
         let default = CodeTheme::default();
-        let expected = crate::code_theme::backend_theme(&default);
+        let expected = crate::code_theme::resolve(&default);
         assert!(std::ptr::eq(selected, expected));
     }
 
@@ -254,8 +254,8 @@ mod tests {
         let options = Options::default().code_theme(theme.clone());
 
         assert!(std::ptr::eq(
-            crate::code_theme::backend_theme(options.selected_code_theme()),
-            crate::code_theme::backend_theme(&theme)
+            crate::code_theme::resolve(options.selected_code_theme()),
+            crate::code_theme::resolve(&theme)
         ));
     }
 }

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -241,10 +241,10 @@ mod tests {
     fn code_theme_has_a_default() {
         let options: Options = Options::default();
 
-        assert!(std::ptr::eq(
-            crate::code_theme::backend_theme(options.selected_code_theme()),
-            crate::code_theme::default_backend_theme()
-        ));
+        let selected = crate::code_theme::backend_theme(options.selected_code_theme());
+        let default = CodeTheme::default();
+        let expected = crate::code_theme::backend_theme(&default);
+        assert!(std::ptr::eq(selected, expected));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add typed selection for syntax-highlighting themes bundled with tui-markdown. Fenced code blocks continue to use Base16 Ocean Dark by default, while applications can opt into another built-in theme through `Options`.

## Example

```rust
use tui_markdown::{from_str_with_options, BuiltinCodeTheme, Options};

let options = Options::default().code_theme(BuiltinCodeTheme::InspiredGitHub);
let text = from_str_with_options("```rust\nfn main() {}\n```", &options);
```

`Options::default()` stores no explicit theme. When the renderer encounters a fenced code block with a recognized language, it borrows the shared Base16 Ocean Dark default. Ordinary Markdown and unrecognized code fences do not initialize the built-in theme set.

`BuiltinCodeTheme` implements `Into<CodeTheme>`, and `Options::code_theme()` accepts either a built-in selector or an already-owned `CodeTheme`. An explicitly selected built-in theme becomes an owned `CodeTheme` ready for rendering. `CodeTheme` stores the concrete theme without retaining a selector, source enum, or provenance state. This gives later constructors one representation for built-in and loaded themes while keeping syntect types and registry names out of the public API.

## Included themes

- Base16 Eighties Dark
- Base16 Mocha Dark
- Base16 Ocean Dark (default)
- Base16 Ocean Light
- Inspired GitHub
- Solarized Dark
- Solarized Light

Originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125), with maintainer follow-up for the renderer-ready theme type, standard conversion API, implementation isolation, optional default configuration, documentation, and boundary tests.

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, warning-denied Rustdoc, doctests, and Markdown linting.
