### PR TITLE
feat(options): load custom code themes

### DIFF
--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -42,6 +42,35 @@ fn main() {}
 let text = from_str_with_options(markdown, &options);
 ```
 
+[`CodeTheme::from_file`] reads and parses a TextMate `.tmTheme` file immediately. The returned theme
+owns the parsed data, so rendering does not access the file again:
+
+```rust
+use tui_markdown::{CodeTheme, CodeThemeLoadError, Options};
+
+fn options() -> Result<Options, CodeThemeLoadError> {
+    let theme = CodeTheme::from_file("themes/solarized.tmTheme")?;
+    Ok(Options::default().code_theme(theme))
+}
+```
+
+Use [`CodeTheme::from_textmate`] with [`include_str!`] to compile a theme into the application
+instead of reading it at runtime:
+
+```rust
+use tui_markdown::{CodeTheme, CodeThemeLoadError, Options};
+
+fn options() -> Result<Options, CodeThemeLoadError> {
+    let source = include_str!("../themes/my-theme.tmTheme");
+    let theme = CodeTheme::from_textmate(source)?;
+    Ok(Options::default().code_theme(theme))
+}
+```
+
+[`CodeTheme`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html
+[`CodeTheme::from_file`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html#method.from_file
+[`CodeTheme::from_textmate`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html#method.from_textmate
+[`include_str!`]: https://doc.rust-lang.org/std/macro.include_str.html
 [`BuiltinCodeTheme`]: https://docs.rs/tui-markdown/latest/tui_markdown/enum.BuiltinCodeTheme.html
 
 ## Status

--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -55,7 +55,8 @@ fn options() -> Result<Options, CodeThemeLoadError> {
 ```
 
 Use [`CodeTheme::from_textmate`] with [`include_str!`] to compile a theme into the application
-instead of reading it at runtime:
+instead of reading it at runtime. The returned theme owns the parsed data and does not borrow the
+source string:
 
 ```rust
 use tui_markdown::{CodeTheme, CodeThemeLoadError, Options};
@@ -67,7 +68,6 @@ fn options() -> Result<Options, CodeThemeLoadError> {
 }
 ```
 
-[`CodeTheme`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html
 [`CodeTheme::from_file`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html#method.from_file
 [`CodeTheme::from_textmate`]: https://docs.rs/tui-markdown/latest/tui_markdown/struct.CodeTheme.html#method.from_textmate
 [`include_str!`]: https://doc.rust-lang.org/std/macro.include_str.html

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -1,22 +1,27 @@
-//! Built-in syntax-highlighting themes for fenced code blocks.
+//! Syntax-highlighting themes for fenced code blocks.
 //!
-//! Pass a [`BuiltinCodeTheme`] to [`Options::code_theme`](crate::Options::code_theme), or convert it
-//! into an owned [`CodeTheme`]. The renderer consults the theme when a fenced code block names a
-//! recognized language.
+//! [`CodeTheme`] represents bundled themes converted from [`BuiltinCodeTheme`] and TextMate themes
+//! parsed with [`CodeTheme::from_textmate`] or loaded with [`CodeTheme::from_file`]. Select any of
+//! them with [`Options::code_theme`](crate::Options::code_theme). The renderer consults the theme
+//! when a fenced code block names a recognized language.
 //!
 //! A configured [`CodeTheme`] owns its theme data. [`Options`](crate::Options) stores no theme by
 //! default; the renderer instead borrows a shared [`CodeTheme`] for
 //! [`BuiltinCodeTheme::Base16OceanDark`] when it first encounters a recognized fenced language.
 
-use std::path::Path;
+use std::error::Error;
+use std::fmt;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use syntect::highlighting::{Theme, ThemeSet};
 
 /// An owned syntax-highlighting theme for fenced code blocks.
 ///
-/// Convert a [`BuiltinCodeTheme`] into this type, or pass the built-in theme directly to
-/// [`Options::code_theme`](crate::Options::code_theme).
+/// Convert a [`BuiltinCodeTheme`] into this type, parse TextMate source with
+/// [`CodeTheme::from_textmate`], or load a TextMate file with [`CodeTheme::from_file`]. Then pass
+/// the theme to [`Options::code_theme`](crate::Options::code_theme).
 ///
 /// The renderer consults the theme only for fenced code blocks whose language is recognized.
 ///
@@ -25,6 +30,52 @@ use syntect::highlighting::{Theme, ThemeSet};
 #[derive(Clone, Debug)]
 pub struct CodeTheme {
     theme: Theme,
+}
+
+impl CodeTheme {
+    /// Parses a TextMate syntax-highlighting theme.
+    ///
+    /// This constructor does not access the filesystem. Applications can combine it with
+    /// [`include_str!`] to compile a theme into their binary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CodeThemeLoadError`] when `source` is not a valid TextMate theme.
+    pub fn from_textmate(source: &str) -> Result<Self, CodeThemeLoadError> {
+        let mut reader = Cursor::new(source);
+        let theme = ThemeSet::load_from_reader(&mut reader)
+            .map_err(|source| CodeThemeLoadError { path: None, source })?;
+        Ok(Self { theme })
+    }
+
+    /// Loads a TextMate syntax-highlighting theme from disk.
+    ///
+    /// This function reads and parses the file synchronously. The resulting `CodeTheme` owns the
+    /// parsed theme, so rendering does not access the file again. Use [`CodeTheme::from_textmate`]
+    /// with [`include_str!`] when the theme should be compiled into the application instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CodeThemeLoadError`] when the file cannot be read or its contents are not a valid
+    /// TextMate theme. The error message includes the requested path.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use tui_markdown::{CodeTheme, Options};
+    ///
+    /// let theme = CodeTheme::from_file("themes/solarized.tmTheme")?;
+    /// let options = Options::default().code_theme(theme);
+    /// # Ok::<(), tui_markdown::CodeThemeLoadError>(())
+    /// ```
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, CodeThemeLoadError> {
+        let path = path.as_ref();
+        let theme = ThemeSet::get_theme(path).map_err(|source| CodeThemeLoadError {
+            path: Some(path.to_owned()),
+            source,
+        })?;
+        Ok(Self { theme })
+    }
 }
 
 /// A syntax-highlighting theme bundled with tui-markdown.
@@ -72,6 +123,43 @@ impl From<BuiltinCodeTheme> for CodeTheme {
     }
 }
 
+/// An error returned when a syntax-highlighting theme cannot be parsed or loaded.
+///
+/// Errors from [`CodeTheme::from_file`] include the requested path. Errors from
+/// [`CodeTheme::from_textmate`] identify invalid TextMate source. [`Error::source`] provides the
+/// underlying parsing error without making the parser part of tui-markdown's public API.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct CodeThemeLoadError {
+    path: Option<PathBuf>,
+    source: syntect::LoadingError,
+}
+
+impl fmt::Display for CodeThemeLoadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(path) = &self.path {
+            write!(
+                formatter,
+                "failed to load code theme from `{}`: {}",
+                path.display(),
+                self.source
+            )
+        } else {
+            write!(
+                formatter,
+                "failed to parse TextMate code theme: {}",
+                self.source
+            )
+        }
+    }
+}
+
+impl Error for CodeThemeLoadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
 /// Returns the syntax-highlighting data for a code theme.
 pub fn theme(code_theme: &CodeTheme) -> &Theme {
     &code_theme.theme
@@ -93,16 +181,16 @@ fn builtin_theme(code_theme: BuiltinCodeTheme) -> &'static Theme {
 }
 
 static DEFAULT_THEME: LazyLock<CodeTheme> = LazyLock::new(|| BuiltinCodeTheme::default().into());
-
-fn load_theme(path: &Path) -> Result<Theme, syntect::LoadingError> {
-    ThemeSet::get_theme(path)
-}
-
 static THEMES: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
 
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+
+    use indoc::indoc;
+    use ratatui_core::style::Color;
+
+    use crate::{from_str_with_options, Options};
 
     use super::*;
 
@@ -129,6 +217,7 @@ mod tests {
             let _ = theme(&code_theme);
         }
     }
+
     #[test]
     fn configured_theme_is_borrowed_directly() {
         let code_theme = CodeTheme::from(BuiltinCodeTheme::SolarizedDark);
@@ -142,7 +231,83 @@ mod tests {
     }
 
     #[test]
-    fn theme_file_can_be_loaded() {
-        load_theme(&fixture("custom.tmTheme")).unwrap();
+    fn loaded_theme_applies_its_foreground_color() {
+        let input = indoc! {"
+            ```rust
+            fn main() {}
+            ```
+        "};
+        let theme = CodeTheme::from_file(fixture("custom.tmTheme")).unwrap();
+        let options = Options::default().code_theme(theme);
+        let loaded = from_str_with_options(input, &options);
+        let keyword = loaded
+            .lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .find(|span| span.content == "fn")
+            .expect("Rust highlighting should emit the `fn` keyword");
+
+        assert_eq!(keyword.style.fg, Some(Color::Rgb(255, 255, 255)));
+    }
+
+    #[test]
+    fn bundled_theme_applies_its_foreground_color() {
+        let input = indoc! {"
+            ```rust
+            fn main() {}
+            ```
+        "};
+        let source = include_str!("code_theme/fixtures/custom.tmTheme");
+        let theme = CodeTheme::from_textmate(source).unwrap();
+        let options = Options::default().code_theme(theme);
+        let bundled = from_str_with_options(input, &options);
+        let keyword = bundled
+            .lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .find(|span| span.content == "fn")
+            .expect("Rust highlighting should emit the `fn` keyword");
+
+        assert_eq!(keyword.style.fg, Some(Color::Rgb(255, 255, 255)));
+    }
+
+    #[test]
+    fn missing_theme_reports_its_path_and_read_error() {
+        let path = fixture("missing.tmTheme");
+        let error = CodeTheme::from_file(&path).unwrap_err();
+
+        let prefix = format!("failed to load code theme from `{}`:", path.display());
+        assert!(error.to_string().starts_with(&prefix));
+        assert!(matches!(&error.source, syntect::LoadingError::Io(_)));
+        assert!(error.source().is_some());
+    }
+
+    #[test]
+    fn malformed_theme_reports_its_path_and_parse_error() {
+        let path = fixture("invalid.tmTheme");
+        let error = CodeTheme::from_file(&path).unwrap_err();
+
+        let prefix = format!("failed to load code theme from `{}`:", path.display());
+        assert!(error.to_string().starts_with(&prefix));
+        assert!(matches!(
+            &error.source,
+            syntect::LoadingError::ReadSettings(_)
+        ));
+        assert!(error.source().is_some());
+    }
+
+    #[test]
+    fn malformed_bundled_theme_reports_a_parse_error() {
+        let error = CodeTheme::from_textmate("this is not a TextMate theme").unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "failed to parse TextMate code theme: Invalid syntax theme settings"
+        );
+        assert!(matches!(
+            &error.source,
+            syntect::LoadingError::ReadSettings(_)
+        ));
+        assert!(error.source().is_some());
     }
 }

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -35,8 +35,9 @@ pub struct CodeTheme {
 impl CodeTheme {
     /// Parses a TextMate syntax-highlighting theme.
     ///
-    /// This constructor does not access the filesystem. Applications can combine it with
-    /// [`include_str!`] to compile a theme into their binary.
+    /// This constructor parses `source` immediately and does not access the filesystem. The
+    /// returned theme owns the parsed data and does not borrow `source`. Applications can combine
+    /// this method with [`include_str!`] to compile a theme into their binary.
     ///
     /// # Errors
     ///
@@ -232,43 +233,41 @@ mod tests {
 
     #[test]
     fn loaded_theme_applies_its_foreground_color() {
-        let input = indoc! {"
-            ```rust
-            fn main() {}
-            ```
-        "};
         let theme = CodeTheme::from_file(fixture("custom.tmTheme")).unwrap();
-        let options = Options::default().code_theme(theme);
-        let loaded = from_str_with_options(input, &options);
-        let keyword = loaded
-            .lines
-            .iter()
-            .flat_map(|line| &line.spans)
-            .find(|span| span.content == "fn")
-            .expect("Rust highlighting should emit the `fn` keyword");
 
-        assert_eq!(keyword.style.fg, Some(Color::Rgb(255, 255, 255)));
+        assert_eq!(
+            rendered_keyword_foreground(theme),
+            Some(Color::Rgb(255, 255, 255))
+        );
     }
 
     #[test]
-    fn bundled_theme_applies_its_foreground_color() {
+    fn embedded_theme_applies_its_foreground_color() {
+        let source = include_str!("code_theme/fixtures/custom.tmTheme");
+        let theme = CodeTheme::from_textmate(source).unwrap();
+
+        assert_eq!(
+            rendered_keyword_foreground(theme),
+            Some(Color::Rgb(255, 255, 255))
+        );
+    }
+
+    fn rendered_keyword_foreground(theme: CodeTheme) -> Option<Color> {
         let input = indoc! {"
             ```rust
             fn main() {}
             ```
         "};
-        let source = include_str!("code_theme/fixtures/custom.tmTheme");
-        let theme = CodeTheme::from_textmate(source).unwrap();
         let options = Options::default().code_theme(theme);
-        let bundled = from_str_with_options(input, &options);
-        let keyword = bundled
+        let rendered = from_str_with_options(input, &options);
+        rendered
             .lines
             .iter()
             .flat_map(|line| &line.spans)
             .find(|span| span.content == "fn")
-            .expect("Rust highlighting should emit the `fn` keyword");
-
-        assert_eq!(keyword.style.fg, Some(Color::Rgb(255, 255, 255)));
+            .expect("Rust highlighting should emit the `fn` keyword")
+            .style
+            .fg
     }
 
     #[test]
@@ -297,13 +296,12 @@ mod tests {
     }
 
     #[test]
-    fn malformed_bundled_theme_reports_a_parse_error() {
+    fn malformed_embedded_theme_reports_a_parse_error() {
         let error = CodeTheme::from_textmate("this is not a TextMate theme").unwrap_err();
 
-        assert_eq!(
-            error.to_string(),
-            "failed to parse TextMate code theme: Invalid syntax theme settings"
-        );
+        assert!(error
+            .to_string()
+            .starts_with("failed to parse TextMate code theme:"));
         assert!(matches!(
             &error.source,
             syntect::LoadingError::ReadSettings(_)

--- a/tui-markdown/src/code_theme.rs
+++ b/tui-markdown/src/code_theme.rs
@@ -8,6 +8,7 @@
 //! default; the renderer instead borrows a shared [`CodeTheme`] for
 //! [`BuiltinCodeTheme::Base16OceanDark`] when it first encounters a recognized fenced language.
 
+use std::path::Path;
 use std::sync::LazyLock;
 
 use syntect::highlighting::{Theme, ThemeSet};
@@ -92,11 +93,24 @@ fn builtin_theme(code_theme: BuiltinCodeTheme) -> &'static Theme {
 }
 
 static DEFAULT_THEME: LazyLock<CodeTheme> = LazyLock::new(|| BuiltinCodeTheme::default().into());
+
+fn load_theme(path: &Path) -> Result<Theme, syntect::LoadingError> {
+    ThemeSet::get_theme(path)
+}
+
 static THEMES: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
+
+    fn fixture(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/code_theme/fixtures")
+            .join(name)
+    }
 
     #[test]
     fn every_builtin_theme_can_be_selected() {
@@ -115,7 +129,6 @@ mod tests {
             let _ = theme(&code_theme);
         }
     }
-
     #[test]
     fn configured_theme_is_borrowed_directly() {
         let code_theme = CodeTheme::from(BuiltinCodeTheme::SolarizedDark);
@@ -126,5 +139,10 @@ mod tests {
     #[test]
     fn default_theme_is_shared() {
         assert!(std::ptr::eq(default(), default()));
+    }
+
+    #[test]
+    fn theme_file_can_be_loaded() {
+        load_theme(&fixture("custom.tmTheme")).unwrap();
     }
 }

--- a/tui-markdown/src/code_theme/fixtures/custom.tmTheme
+++ b/tui-markdown/src/code_theme/fixtures/custom.tmTheme
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>tui-markdown test theme</string>
+  <key>settings</key>
+  <array>
+    <dict>
+      <key>settings</key>
+      <dict>
+        <key>background</key>
+        <string>#000000</string>
+        <key>foreground</key>
+        <string>#FFFFFF</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Keywords</string>
+      <key>scope</key>
+      <string>keyword</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#FF0000</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/tui-markdown/src/code_theme/fixtures/invalid.tmTheme
+++ b/tui-markdown/src/code_theme/fixtures/invalid.tmTheme
@@ -1,0 +1,1 @@
+this is not a TextMate theme

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -65,7 +65,7 @@ use tracing::{debug, instrument, warn};
 
 #[doc(inline)]
 #[cfg(feature = "highlight-code")]
-pub use crate::code_theme::{BuiltinCodeTheme, CodeTheme};
+pub use crate::code_theme::{BuiltinCodeTheme, CodeTheme, CodeThemeLoadError};
 pub use crate::options::{ImageFallback, Options};
 pub use crate::style_sheet::{AlertKind, DefaultStyleSheet, StyleSheet};
 

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -13,8 +13,9 @@
 //! resources.
 //!
 //! The default `highlight-code` feature highlights fenced code blocks whose language is recognized,
-//! using `Base16OceanDark` unless [`Options`] selects another built-in theme.
-//! Fences without a recognized language remain unhighlighted.
+//! using `Base16OceanDark` unless [`Options`] selects another `CodeTheme`.
+//! Themes can be bundled with tui-markdown, parsed from TextMate source, or loaded from a TextMate
+//! file. Fences without a recognized language remain unhighlighted.
 #![cfg_attr(feature = "document-features", doc = "\n# Features")]
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 //! # Example

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -128,8 +128,10 @@ impl<S: StyleSheet> Options<S> {
     /// By default, no explicit theme is stored and the renderer borrows its shared
     /// [`Base16OceanDark`](crate::BuiltinCodeTheme::Base16OceanDark) theme.
     /// Pass a [`BuiltinCodeTheme`](crate::BuiltinCodeTheme) directly, or pass an owned
-    /// [`CodeTheme`] constructed by another theme source. The selected theme applies when a fenced
-    /// code block names a recognized language.
+    /// [`CodeTheme`]. Construct custom themes from TextMate source with
+    /// [`CodeTheme::from_textmate`](crate::CodeTheme::from_textmate), or load a TextMate file with
+    /// [`CodeTheme::from_file`](crate::CodeTheme::from_file). The selected theme applies when a
+    /// fenced code block names a recognized language.
     ///
     /// # Example
     ///


### PR DESCRIPTION
## Summary

Load TextMate `.tmTheme` files or parse bundled TextMate source into the same `CodeTheme` used for built-in syntax-highlighting themes. Applications create a theme before configuring `Options`; rendering does not need to know whether the theme came from disk or the application binary.

`Options::default()` stores no explicit theme. When the renderer encounters a fenced code block with a recognized language, it borrows the shared `Base16OceanDark` default; ordinary Markdown and unrecognized code fences do not initialize the built-in theme set. Explicit built-in, file-loaded, and in-memory themes all become the same owned `CodeTheme` value, with no source/provenance state or additional indirection retained during rendering.

## Load a theme at runtime

```rust
use tui_markdown::{from_str_with_options, CodeTheme, CodeThemeLoadError, Options};

fn render() -> Result<(), CodeThemeLoadError> {
    let theme = CodeTheme::from_file("themes/my-theme.tmTheme")?;
    let options = Options::default().code_theme(theme);
    let text = from_str_with_options("```rust\nfn main() {}\n```", &options);
    Ok(())
}
```

`CodeTheme::from_file()` reads and parses the file immediately. The resulting value owns the loaded theme, so rendering performs no filesystem access.

## Bundle a theme with the application

```rust
use tui_markdown::{CodeTheme, CodeThemeLoadError, Options};

fn options() -> Result<Options, CodeThemeLoadError> {
    let source = include_str!("../themes/my-theme.tmTheme");
    let theme = CodeTheme::from_textmate(source)?;
    Ok(Options::default().code_theme(theme))
}
```

`CodeTheme::from_textmate()` parses an in-memory TextMate theme. Combined with `include_str!`, it supports distributing a custom theme without a runtime file dependency.

Loading and parsing failures use the crate-owned `CodeThemeLoadError`. File errors report the requested path, while bundled-source errors identify invalid TextMate content. Both preserve the underlying error as their source without exposing syntect in tui-markdown's public API.

This PR is stacked on [#158](https://github.com/joshka/tui-markdown/pull/158), which introduces the shared `CodeTheme` type and built-in theme conversion. Curating additional built-in assets or integrating a broader Ratatui theme model remains separate from this source-loading API.

Originally contributed by @lightsofapollo in [#125](https://github.com/joshka/tui-markdown/pull/125), with maintainer follow-up for the unified API, opaque error boundary, bundled-source support, documentation, and read/parse/render failure coverage.

Validated with formatting, warning-denied Clippy, workspace tests, no-default-feature tests, Rust 1.88, warning-denied Rustdoc, doctests, and Markdown linting.
