### PR TITLE
docs(renderer): clarify rendering contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ repository root.
 
 ## Coding Style & Naming Conventions
 
-Code targets Rust 1.86 (edition 2021) and follows standard Rust naming (`snake_case` functions,
+Code targets Rust 1.88 (edition 2021) and follows standard Rust naming (`snake_case` functions,
 `PascalCase` types). `rustfmt.toml` enforces grouped imports, wrapped comments, and a 100-column
 guide; run `cargo fmt` before review. Prefer explicit module re-exports for library APIs and keep
 public surfaces documented with `///` comments. Clippy must run clean before submitting changes.

--- a/markdown-reader/README.md
+++ b/markdown-reader/README.md
@@ -56,6 +56,7 @@ This is working code, but not every markdown feature is supported. PRs welcome!
 - [x] Unordered lists
 - [x] Code blocks
 - [x] HTML
+- [x] Math
 - [x] Footnotes
 - [x] Definition lists
 - [x] Tables

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -1,21 +1,24 @@
-//! A simple markdown renderer widget for Ratatui.
+//! Convert Markdown into Ratatui [`Text`](ratatui_core::text::Text).
 //!
-//! This module provides a simple markdown renderer widget for Ratatui. It uses the `pulldown-cmark`
-//! crate to parse markdown and convert it to a `Text` widget. The `Text` widget can then be
-//! rendered to the terminal using the 'Ratatui' library.
+//! [`from_str`] renders with the default styles and options. [`from_str_with_options`] accepts an
+//! [`Options`] value for a custom [`StyleSheet`], image fallback mode, and, when the
+//! `highlight-code` feature is enabled, syntax-highlighting theme.
 //!
-//! GitHub-flavored Markdown tables render with Unicode box-drawing borders, terminal-width-aware
-//! columns, and the alignment declared by the Markdown delimiter row. Use [`StyleSheet`] to
-//! customize header cells, body cells, and borders.
+//! The returned text may borrow from the Markdown input. It contains terminal text and styles only;
+//! image syntax produces a configurable text fallback and does not read or render image resources.
 //!
-//! Images render as `[img]` followed by their description, or by their destination when the
-//! description is empty. This is a text fallback; the crate does not load or render image
-//! resources.
+//! # Markdown output
 //!
-//! The default `highlight-code` feature highlights fenced code blocks whose language is recognized,
-//! using `Base16OceanDark` unless [`Options`] selects another `CodeTheme`.
-//! Themes can be bundled with tui-markdown, parsed from TextMate source, or loaded from a TextMate
-//! file. Fences without a recognized language remain unhighlighted.
+//! Tables use Unicode box-drawing borders, terminal display widths, and the alignment declared by
+//! the Markdown delimiter row. Raw HTML stays visible as literal text. Math retains its delimiters,
+//! and images render as `[img]` followed by their description or destination.
+//!
+//! # Syntax highlighting
+//!
+//! The default `highlight-code` feature highlights fenced code blocks whose language is recognized.
+//! It uses `Base16OceanDark` unless [`Options`] selects another [`CodeTheme`]. Themes can come from
+//! the built-in set, TextMate source bundled with the application, or a TextMate file read before
+//! rendering. Unrecognized code fences use [`StyleSheet::code`] instead.
 #![cfg_attr(feature = "document-features", doc = "\n# Features")]
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 //!

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -39,11 +39,10 @@ pub enum ImageFallback {
     AltTextAndUrl,
 }
 
-/// Collection of optional parameters that influence markdown rendering.
+/// Rendering options for [`crate::from_str_with_options`].
 ///
-/// The generic `S` allows users to provide their own theme type that implements the
-/// [`StyleSheet`] trait. The default implementation is [`DefaultStyleSheet`], which provides a
-/// set of sensible defaults for styling markdown elements.
+/// `S` is the style sheet consulted while Markdown events are rendered. [`Options::default`] uses
+/// [`DefaultStyleSheet`]. Use [`Options::new`] to supply another [`StyleSheet`].
 ///
 /// # Example
 ///
@@ -104,7 +103,9 @@ pub struct Options<S: StyleSheet = DefaultStyleSheet> {
 }
 
 impl<S: StyleSheet> Options<S> {
-    /// Creates a new `Options` instance with the provided style sheet.
+    /// Creates rendering options that use `styles`.
+    ///
+    /// Image fallback and syntax-highlighting settings retain their defaults.
     pub fn new(styles: S) -> Self {
         Self {
             styles,

--- a/tui-markdown/src/renderer/blockquote.rs
+++ b/tui-markdown/src/renderer/blockquote.rs
@@ -75,7 +75,7 @@ fn alert_kind(kind: BlockQuoteKind) -> AlertKind {
 
 #[cfg(test)]
 mod tests {
-    use indoc::indoc;
+    use indoc::{formatdoc, indoc};
     use rstest::rstest;
 
     use super::*;
@@ -181,7 +181,11 @@ mod tests {
             #[case] heading: &str,
             #[case] style: Style,
         ) {
-            let markdown = format!("> [!{marker}]\n> Body");
+            let markdown = formatdoc! {"
+                > [!{marker}]
+                > Body
+            "};
+
             assert_eq!(
                 from_str(&markdown),
                 Text::from_iter([
@@ -199,11 +203,15 @@ mod tests {
 
         #[rstest]
         fn custom_alert_style_applies_to_header_and_body(_with_tracing: DefaultGuard) {
-            let style = Style::new().on_red();
+            let markdown = indoc! {"
+                > [!NOTE]
+                > Body
+            "};
             let options = Options::new(CustomAlertStyleSheet);
+            let style = Style::new().on_red();
 
             assert_eq!(
-                from_str_with_options("> [!NOTE]\n> Body", &options),
+                from_str_with_options(markdown, &options),
                 Text::from_iter([
                     Line::from_iter([
                         Span::raw(">"),
@@ -219,11 +227,15 @@ mod tests {
 
         #[rstest]
         fn custom_alert_icon_replaces_default(_with_tracing: DefaultGuard) {
-            let style = DefaultStyleSheet.alert(AlertKind::Note);
+            let markdown = indoc! {"
+                > [!NOTE]
+                > Body
+            "};
             let options = Options::new(CustomAlertHeadingStyleSheet);
+            let style = DefaultStyleSheet.alert(AlertKind::Note);
 
             assert_eq!(
-                from_str_with_options("> [!NOTE]\n> Body", &options),
+                from_str_with_options(markdown, &options),
                 Text::from_iter([
                     Line::from_iter([
                         Span::raw(">"),
@@ -239,11 +251,15 @@ mod tests {
 
         #[rstest]
         fn empty_alert_icon_suppresses_icon_and_separator(_with_tracing: DefaultGuard) {
-            let style = DefaultStyleSheet.alert(AlertKind::Caution);
+            let markdown = indoc! {"
+                > [!CAUTION]
+                > Body
+            "};
             let options = Options::new(CustomAlertHeadingStyleSheet);
+            let style = DefaultStyleSheet.alert(AlertKind::Caution);
 
             assert_eq!(
-                from_str_with_options("> [!CAUTION]\n> Body", &options),
+                from_str_with_options(markdown, &options),
                 Text::from_iter([
                     Line::from_iter([
                         Span::raw(">"),
@@ -259,11 +275,15 @@ mod tests {
 
         #[rstest]
         fn custom_alert_label_replaces_default(_with_tracing: DefaultGuard) {
-            let style = DefaultStyleSheet.alert(AlertKind::Tip);
+            let markdown = indoc! {"
+                > [!TIP]
+                > Body
+            "};
             let options = Options::new(CustomAlertHeadingStyleSheet);
+            let style = DefaultStyleSheet.alert(AlertKind::Tip);
 
             assert_eq!(
-                from_str_with_options("> [!TIP]\n> Body", &options),
+                from_str_with_options(markdown, &options),
                 Text::from_iter([
                     Line::from_iter([
                         Span::raw(">"),
@@ -279,11 +299,15 @@ mod tests {
 
         #[rstest]
         fn empty_alert_label_suppresses_label_and_separator(_with_tracing: DefaultGuard) {
-            let style = DefaultStyleSheet.alert(AlertKind::Important);
+            let markdown = indoc! {"
+                > [!IMPORTANT]
+                > Body
+            "};
             let options = Options::new(CustomAlertHeadingStyleSheet);
+            let style = DefaultStyleSheet.alert(AlertKind::Important);
 
             assert_eq!(
-                from_str_with_options("> [!IMPORTANT]\n> Body", &options),
+                from_str_with_options(markdown, &options),
                 Text::from_iter([
                     Line::from_iter([
                         Span::raw(">"),
@@ -308,9 +332,14 @@ mod tests {
 
         #[rstest]
         fn nested_blockquote_keeps_each_standard_prefix(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > Parent
+                >> Child
+            "};
             let style = DefaultStyleSheet.blockquote();
+
             assert_eq!(
-                from_str("> Parent\n>> Child"),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from_iter([">", " ", "Parent"]).style(style),
                     Line::from_iter([">", " "]).style(style),
@@ -321,10 +350,16 @@ mod tests {
 
         #[rstest]
         fn alert_preserves_nested_blockquote(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > [!NOTE]
+                > Parent
+                >> Child
+            "};
             let alert_style = Style::new().blue();
             let blockquote_style = DefaultStyleSheet.blockquote();
+
             assert_eq!(
-                from_str("> [!NOTE]\n> Parent\n>> Child"),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from_iter([
                         Span::raw(">"),
@@ -359,12 +394,14 @@ mod tests {
         /// test is to help debug and ensure that.
         #[rstest]
         fn after_paragraph(_with_tracing: DefaultGuard) {
-            assert_eq!(
-                from_str(indoc! {"
+            let markdown = indoc! {"
                 Hello, world!
 
                 > Blockquote
-            "}),
+            "};
+
+            assert_eq!(
+                from_str(markdown),
                 Text::from_iter([
                     Line::from("Hello, world!"),
                     Line::default(),
@@ -372,6 +409,25 @@ mod tests {
                 ])
             );
         }
+
+        #[rstest]
+        fn style_does_not_leak_into_following_paragraph(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                > Blockquote
+
+                After
+            "};
+
+            assert_eq!(
+                from_str(markdown),
+                Text::from_iter([
+                    Line::from_iter([">", " ", "Blockquote"]).style(STYLE),
+                    Line::default(),
+                    Line::from("After"),
+                ])
+            );
+        }
+
         #[rstest]
         fn single(_with_tracing: DefaultGuard) {
             assert_eq!(
@@ -382,11 +438,13 @@ mod tests {
 
         #[rstest]
         fn soft_break(_with_tracing: DefaultGuard) {
-            assert_eq!(
-                from_str(indoc! {"
+            let markdown = indoc! {"
                 > Blockquote 1
                 > Blockquote 2
-            "}),
+            "};
+
+            assert_eq!(
+                from_str(markdown),
                 Text::from(
                     Line::from_iter([">", " ", "Blockquote 1", " ", "Blockquote 2"]).style(STYLE)
                 )
@@ -395,12 +453,14 @@ mod tests {
 
         #[rstest]
         fn multiple(_with_tracing: DefaultGuard) {
-            assert_eq!(
-                from_str(indoc! {"
+            let markdown = indoc! {"
                 > Blockquote 1
                 >
                 > Blockquote 2
-            "}),
+            "};
+
+            assert_eq!(
+                from_str(markdown),
                 Text::from_iter([
                     Line::from_iter([">", " ", "Blockquote 1"]).style(STYLE),
                     Line::from_iter([">", " "]).style(STYLE),
@@ -411,12 +471,14 @@ mod tests {
 
         #[rstest]
         fn multiple_with_break(_with_tracing: DefaultGuard) {
-            assert_eq!(
-                from_str(indoc! {"
+            let markdown = indoc! {"
                 > Blockquote 1
 
                 > Blockquote 2
-            "}),
+            "};
+
+            assert_eq!(
+                from_str(markdown),
                 Text::from_iter([
                     Line::from_iter([">", " ", "Blockquote 1"]).style(STYLE),
                     Line::default(),
@@ -427,11 +489,13 @@ mod tests {
 
         #[rstest]
         fn nested(_with_tracing: DefaultGuard) {
-            assert_eq!(
-                from_str(indoc! {"
+            let markdown = indoc! {"
                 > Blockquote 1
                 >> Nested Blockquote
-            "}),
+            "};
+
+            assert_eq!(
+                from_str(markdown),
                 Text::from_iter([
                     Line::from_iter([">", " ", "Blockquote 1"]).style(STYLE),
                     Line::from_iter([">", " "]).style(STYLE),

--- a/tui-markdown/src/renderer/blockquote.rs
+++ b/tui-markdown/src/renderer/blockquote.rs
@@ -1,4 +1,7 @@
 //! Markdown blockquote and GFM alert rendering.
+//!
+//! Plain blockquotes use the configured blockquote style and `>` prefix. A recognized GFM alert
+//! adds a styled icon and label, then renders its body with the alert style.
 
 use pulldown_cmark::{BlockQuoteKind, Event};
 use ratatui_core::style::Style;

--- a/tui-markdown/src/renderer/code.rs
+++ b/tui-markdown/src/renderer/code.rs
@@ -207,6 +207,20 @@ mod tests {
         );
     }
 
+    #[rstest]
+    fn fenced_code_style_does_not_leak_into_following_paragraph(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            ```rust
+            fn main() {}
+            ```
+
+            After
+        "};
+        let text = from_str(markdown);
+
+        assert_eq!(text.lines.last(), Some(&Line::from("After")));
+    }
+
     #[cfg(feature = "highlight-code")]
     mod code_theme {
         use pretty_assertions::assert_eq;

--- a/tui-markdown/src/renderer/code.rs
+++ b/tui-markdown/src/renderer/code.rs
@@ -1,4 +1,7 @@
 //! Markdown inline and fenced code rendering.
+//!
+//! Inline code and unrecognized fences use the style sheet's code style. With `highlight-code`
+//! enabled, a recognized fenced language uses the selected syntax-highlighting theme.
 
 #[cfg(feature = "highlight-code")]
 use std::sync::LazyLock;

--- a/tui-markdown/src/renderer/definition_list.rs
+++ b/tui-markdown/src/renderer/definition_list.rs
@@ -1,4 +1,7 @@
 //! Markdown definition-list rendering.
+//!
+//! Terms and descriptions have separate styles. Each description starts with `: `, and paragraph
+//! handling preserves blank lines inside multi-paragraph descriptions.
 
 use pulldown_cmark::Event;
 use ratatui_core::text::{Line, Span};

--- a/tui-markdown/src/renderer/definition_list.rs
+++ b/tui-markdown/src/renderer/definition_list.rs
@@ -58,6 +58,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
     use rstest::rstest;
 
     use super::*;
@@ -109,8 +110,13 @@ mod tests {
 
         #[rstest]
         fn exact_output_and_default_styles(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term
+                : Definition
+            "};
+
             assert_eq!(
-                from_str("Term\n: Definition\n"),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from(Span::styled("Term", Style::new().bold())),
                     Line::from_iter([Span::raw(": "), Span::raw("Definition")]),
@@ -120,13 +126,16 @@ mod tests {
 
         #[rstest]
         fn custom_styles_apply_to_terms_and_definitions(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term
+                : Definition
+            "};
             let options = Options::new(CustomDefinitionStyleSheet);
-            let text = from_str_with_options("Term\n: Definition\n", &options);
             let title_style = Style::new().red().underlined();
             let description_style = Style::new().blue().italic();
 
             assert_eq!(
-                text,
+                from_str_with_options(markdown, &options),
                 Text::from_iter([
                     Line::from(Span::styled("Term", title_style)),
                     Line::from_iter([
@@ -139,12 +148,16 @@ mod tests {
 
         #[rstest]
         fn inline_formatting_combines_with_definition_styles(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                *Term*
+                : **Description**
+            "};
             let options = Options::new(CustomDefinitionStyleSheet);
             let term_style = Style::new().red().underlined().italic();
             let description_style = Style::new().blue().italic();
 
             assert_eq!(
-                from_str_with_options("*Term*\n: **Description**\n", &options),
+                from_str_with_options(markdown, &options),
                 Text::from_iter([
                     Line::from(Span::styled("Term", term_style)),
                     Line::from_iter([
@@ -157,8 +170,14 @@ mod tests {
 
         #[rstest]
         fn multiline_definition(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term
+                : First line
+                  second line
+            "};
+
             assert_eq!(
-                from_str("Term\n: First line\n  second line\n"),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from(Span::styled("Term", Style::new().bold())),
                     Line::from_iter([
@@ -173,8 +192,14 @@ mod tests {
 
         #[rstest]
         fn multiple_descriptions(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term
+                : First description
+                : Second description
+            "};
+
             assert_eq!(
-                from_str("Term\n: First description\n: Second description\n"),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from(Span::styled("Term", Style::new().bold())),
                     Line::from_iter([Span::raw(": "), Span::raw("First description")]),
@@ -185,8 +210,15 @@ mod tests {
 
         #[rstest]
         fn multiple_description_paragraphs_keep_prefix_and_blank_line(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term
+                : First paragraph.
+
+                  Second paragraph.
+            "};
+
             assert_eq!(
-                from_str("Term\n: First paragraph.\n\n  Second paragraph."),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from(Span::styled("Term", Style::new().bold())),
                     Line::from_iter([Span::raw(": "), Span::raw("First paragraph.")]),
@@ -198,11 +230,19 @@ mod tests {
 
         #[rstest]
         fn repeated_items_do_not_leak_into_following_paragraph(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Term one
+                : First description.
+
+                Term two
+                : Second description.
+
+                After.
+            "};
             let term_style = Style::new().bold();
+
             assert_eq!(
-                from_str(
-                    "Term one\n: First description.\n\nTerm two\n: Second description.\n\nAfter."
-                ),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from(Span::styled("Term one", term_style)),
                     Line::from_iter([Span::raw(": "), Span::raw("First description.")]),

--- a/tui-markdown/src/renderer/footnote.rs
+++ b/tui-markdown/src/renderer/footnote.rs
@@ -45,6 +45,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
     use rstest::rstest;
 
     use super::*;
@@ -59,11 +60,17 @@ mod tests {
 
         #[rstest]
         fn multiline_definition_has_exact_layout(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Text[^one]
+
+                [^one]: First line
+                    continued line.
+            "};
             let reference_style = Style::new().dim().italic();
             let definition_style = Style::new().dim();
 
             assert_eq!(
-                from_str("Text[^one]\n\n[^one]: First line\n    continued line."),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from_iter([Span::raw("Text"), Span::styled("[one]", reference_style),]),
                     Line::default(),
@@ -80,11 +87,18 @@ mod tests {
 
         #[rstest]
         fn multiple_definitions_have_exact_layout(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                First[^a] second[^b].
+
+                [^a]: Alpha.
+
+                [^b]: Beta.
+            "};
             let reference_style = Style::new().dim().italic();
             let definition_style = Style::new().dim();
 
             assert_eq!(
-                from_str("First[^a] second[^b].\n\n[^a]: Alpha.\n\n[^b]: Beta."),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from_iter([
                         Span::raw("First"),
@@ -107,9 +121,15 @@ mod tests {
 
         #[rstest]
         fn reference_combines_with_enclosing_style(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                **Text[^one]**
+
+                [^one]: Note.
+            "};
             let reference_style = Style::new().bold().dim().italic();
+
             assert_eq!(
-                from_str("**Text[^one]**\n\n[^one]: Note."),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from_iter([
                         Span::styled("Text", Style::new().bold()),
@@ -127,9 +147,17 @@ mod tests {
 
         #[rstest]
         fn multiple_definition_paragraphs_keep_blank_line(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Text[^one]
+
+                [^one]: First paragraph.
+
+                    Second paragraph.
+            "};
             let definition_style = Style::new().dim();
+
             assert_eq!(
-                from_str("Text[^one]\n\n[^one]: First paragraph.\n\n    Second paragraph."),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from_iter([
                         Span::raw("Text"),
@@ -149,11 +177,19 @@ mod tests {
 
         #[rstest]
         fn definition_style_does_not_leak_into_following_paragraph(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Text[^one]
+
+                [^one]: First paragraph.
+
+                    Second paragraph.
+
+                After.
+            "};
             let definition_style = Style::new().dim();
+
             assert_eq!(
-                from_str(
-                    "Text[^one]\n\n[^one]: First paragraph.\n\n    Second paragraph.\n\nAfter."
-                ),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from_iter([
                         Span::raw("Text"),
@@ -212,11 +248,17 @@ mod tests {
                 }
             }
 
+            let markdown = indoc! {"
+                **Text[^one]**
+
+                [^one]: Note.
+            "};
+            let options = Options::new(CustomFootnoteStyle);
             let reference_style = Style::new().red().bold().underlined();
             let definition_style = Style::new().blue().underlined();
-            let options = Options::new(CustomFootnoteStyle);
+
             assert_eq!(
-                from_str_with_options("**Text[^one]**\n\n[^one]: Note.", &options),
+                from_str_with_options(markdown, &options),
                 Text::from_iter([
                     Line::from_iter([
                         Span::styled("Text", Style::new().bold()),

--- a/tui-markdown/src/renderer/footnote.rs
+++ b/tui-markdown/src/renderer/footnote.rs
@@ -1,4 +1,7 @@
 //! Markdown footnote rendering.
+//!
+//! References render inline as `[label]`. Definitions start with `[label]: ` and retain paragraph
+//! boundaries without leaking their line style into following content.
 
 use pulldown_cmark::{CowStr, Event};
 use ratatui_core::text::{Line, Span};

--- a/tui-markdown/src/renderer/formatting.rs
+++ b/tui-markdown/src/renderer/formatting.rs
@@ -1,4 +1,7 @@
 //! Markdown inline formatting.
+//!
+//! The inline style stack patches nested formatting over its enclosing style. Closing a formatting
+//! tag restores the previous style.
 
 use pulldown_cmark::Event;
 use ratatui_core::style::Style;

--- a/tui-markdown/src/renderer/formatting.rs
+++ b/tui-markdown/src/renderer/formatting.rs
@@ -98,4 +98,16 @@ mod tests {
             ]))
         );
     }
+
+    #[rstest]
+    fn formatting_does_not_leak_into_following_text(_with_tracing: DefaultGuard) {
+        assert_eq!(
+            from_str("Before **strong** after"),
+            Text::from(Line::from_iter([
+                Span::raw("Before "),
+                Span::raw("strong").bold(),
+                Span::raw(" after"),
+            ]))
+        );
+    }
 }

--- a/tui-markdown/src/renderer/heading.rs
+++ b/tui-markdown/src/renderer/heading.rs
@@ -148,4 +148,28 @@ mod tests {
             )
         );
     }
+
+    #[rstest]
+    fn heading_attributes_do_not_carry_to_next_heading(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            # First {#first}
+            # Second
+        "};
+        let h1 = Style::new().on_cyan().bold().underlined();
+        let meta = Style::new().dim();
+
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter([
+                    Span::raw("# "),
+                    Span::raw("First"),
+                    Span::styled(" {#first}", meta),
+                ])
+                .style(h1),
+                Line::default(),
+                Line::from_iter([Span::raw("# "), Span::raw("Second")]).style(h1),
+            ])
+        );
+    }
 }

--- a/tui-markdown/src/renderer/heading.rs
+++ b/tui-markdown/src/renderer/heading.rs
@@ -1,4 +1,7 @@
 //! Markdown heading rendering.
+//!
+//! Headings retain their Markdown `#` prefix. IDs, classes, and key-value attributes render as a
+//! styled attribute-block suffix after the heading text.
 
 use pulldown_cmark::{CowStr, Event, HeadingLevel};
 use ratatui_core::text::{Line, Span};

--- a/tui-markdown/src/renderer/html.rs
+++ b/tui-markdown/src/renderer/html.rs
@@ -49,6 +49,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
     use rstest::rstest;
 
     use super::*;
@@ -90,8 +91,18 @@ mod tests {
 
         #[rstest]
         fn html_block_preserves_paragraph_spacing(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Before
+
+                <div>
+                Custom HTML
+                </div>
+
+                After
+            "};
+
             assert_eq!(
-                from_str("Before\n\n<div>\nCustom HTML\n</div>\n\nAfter"),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from("Before"),
                     Line::default(),

--- a/tui-markdown/src/renderer/html.rs
+++ b/tui-markdown/src/renderer/html.rs
@@ -1,4 +1,7 @@
 //! Raw Markdown HTML rendering.
+//!
+//! HTML remains visible as literal text. Inline tags compose with enclosing formatting, while HTML
+//! blocks preserve their physical lines and surrounding block spacing.
 
 use pulldown_cmark::{CowStr, Event};
 use ratatui_core::text::{Line, Span};

--- a/tui-markdown/src/renderer/link.rs
+++ b/tui-markdown/src/renderer/link.rs
@@ -70,4 +70,24 @@ mod tests {
             ]))
         );
     }
+
+    #[rstest]
+    fn consecutive_links_restore_surrounding_style(_with_tracing: DefaultGuard) {
+        let link_style = Style::new().blue().underlined();
+        assert_eq!(
+            from_str("[One](one) and [Two](two) after"),
+            Text::from(Line::from_iter([
+                Span::styled("One", link_style),
+                Span::raw(" ("),
+                Span::styled("one", link_style),
+                Span::raw(")"),
+                Span::raw(" and "),
+                Span::styled("Two", link_style),
+                Span::raw(" ("),
+                Span::styled("two", link_style),
+                Span::raw(")"),
+                Span::raw(" after"),
+            ]))
+        );
+    }
 }

--- a/tui-markdown/src/renderer/link.rs
+++ b/tui-markdown/src/renderer/link.rs
@@ -1,4 +1,7 @@
 //! Markdown link rendering.
+//!
+//! Links render as `label (destination)`. The link style applies to the label and destination while
+//! nested inline formatting remains on the label.
 
 use pulldown_cmark::{CowStr, Event};
 use ratatui_core::text::Span;

--- a/tui-markdown/src/renderer/list.rs
+++ b/tui-markdown/src/renderer/list.rs
@@ -145,6 +145,22 @@ mod tests {
     }
 
     #[rstest]
+    fn ordered_list_respects_start_index(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            10. Tenth
+            11. Eleventh
+        "};
+
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter(["10. ".light_blue(), "Tenth".into()]),
+                Line::from_iter(["11. ".light_blue(), "Eleventh".into()]),
+            ])
+        );
+    }
+
+    #[rstest]
     fn list_nested(_with_tracing: DefaultGuard) {
         assert_eq!(
             from_str(indoc! {"
@@ -182,6 +198,24 @@ mod tests {
             Text::from_iter([
                 Line::from_iter(["1. ".light_blue(), "[ ] ".into(), "Incomplete".into(),]),
                 Line::from_iter(["2. ".light_blue(), "[x] ".into(), "Complete".into(),]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn list_does_not_indent_following_paragraph(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            - Item
+
+            After
+        "};
+
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter(["- ", "Item"]),
+                Line::default(),
+                Line::from("After"),
             ])
         );
     }

--- a/tui-markdown/src/renderer/math.rs
+++ b/tui-markdown/src/renderer/math.rs
@@ -1,4 +1,7 @@
 //! Markdown inline and display math rendering.
+//!
+//! Inline math retains `$` delimiters and its position in the surrounding line. Display math keeps
+//! `$$` delimiters and writes each source line as a physical Ratatui line.
 
 use pulldown_cmark::{CowStr, Event};
 use ratatui_core::text::{Line, Span};

--- a/tui-markdown/src/renderer/math.rs
+++ b/tui-markdown/src/renderer/math.rs
@@ -38,6 +38,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
     use rstest::rstest;
 
     use super::*;
@@ -74,9 +75,20 @@ mod tests {
 
         #[rstest]
         fn multiline_display_math_styles_every_line(_with_tracing: DefaultGuard) {
+            let markdown = indoc! {"
+                Before
+
+                $$
+                x = y
+                y = z
+                $$
+
+                After
+            "};
             let style = Style::new().fg(Color::Magenta);
+
             assert_eq!(
-                from_str("Before\n\n$$\nx = y\ny = z\n$$\n\nAfter"),
+                from_str(markdown),
                 Text::from_iter([
                     Line::from("Before"),
                     Line::default(),
@@ -125,10 +137,17 @@ mod tests {
                 }
             }
 
-            let style = Style::new().red().bold();
+            let markdown = indoc! {"
+                $$
+                x = y
+                y = z
+                $$
+            "};
             let options = Options::new(CustomMathStyle);
+            let style = Style::new().red().bold();
+
             assert_eq!(
-                from_str_with_options("$$\nx = y\ny = z\n$$", &options),
+                from_str_with_options(markdown, &options),
                 Text::from_iter([
                     Line::from(Span::styled("$$", style)),
                     Line::from(Span::styled("x = y", style)),

--- a/tui-markdown/src/renderer/mod.rs
+++ b/tui-markdown/src/renderer/mod.rs
@@ -456,6 +456,16 @@ mod tests {
     }
 
     #[rstest]
+    fn paragraph_hard_break(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {r"
+            Hello\
+            World
+        "};
+
+        assert_eq!(from_str(markdown), Text::from_iter(["Hello", "World"]));
+    }
+
+    #[rstest]
     fn paragraph_multiple(_with_tracing: DefaultGuard) {
         assert_eq!(
             from_str(indoc! {"

--- a/tui-markdown/src/renderer/mod.rs
+++ b/tui-markdown/src/renderer/mod.rs
@@ -3,6 +3,10 @@
 //! [`TextWriter`] owns the event loop and shared output state. The event matches remain here as an
 //! index of supported pulldown-cmark events, while each Markdown construct keeps its state,
 //! rendering behavior, and tests in the corresponding child module.
+//!
+//! Inline handlers ultimately write spans through [`TextWriter::push_span`]. Active image
+//! descriptions receive those spans first, followed by active table cells, then the output line.
+//! This sink order preserves inline event ordering inside buffered constructs.
 
 use std::vec;
 
@@ -34,25 +38,36 @@ mod test_support;
 
 /// Render Markdown `input` into a [`Text`] using the default [`Options`].
 ///
-/// This is a convenience function that uses the default options, which are defined in
-/// [`Options::default`]. Image syntax renders as a styled text fallback so its description or
-/// destination remains visible in terminals without image graphics.
+/// The returned text may borrow from `input`. Image syntax renders as a styled text fallback; this
+/// function does not read or render image resources.
+///
+/// # Example
+///
+/// ```
+/// use tui_markdown::from_str;
+///
+/// let text = from_str("# Status\n\nReady");
+///
+/// assert_eq!(text.to_string(), "# Status\n\nReady");
+/// ```
 pub fn from_str(input: &str) -> Text<'_> {
     from_str_with_options(input, &Options::default())
 }
 
 /// Render Markdown `input` into a [`Text`] using the supplied [`Options`].
 ///
-/// This allows you to customize the styles and other rendering options.
+/// The returned text may borrow from `input`. The options control styles, image fallback content,
+/// and, with the `highlight-code` feature, fenced-code syntax highlighting.
 ///
 /// # Example
 ///
 /// ```
-/// use tui_markdown::{from_str_with_options, DefaultStyleSheet, Options};
+/// use tui_markdown::{from_str_with_options, ImageFallback, Options};
 ///
-/// let input = "This is a **bold** text.";
-/// let options = Options::default();
-/// let text = from_str_with_options(input, &options);
+/// let options = Options::default().image_fallback(ImageFallback::AltTextAndUrl);
+/// let text = from_str_with_options("![diagram](diagram.png)", &options);
+///
+/// assert_eq!(text.to_string(), "[img] diagram (diagram.png)");
 /// ```
 pub fn from_str_with_options<'a, S>(input: &'a str, options: &Options<S>) -> Text<'a>
 where

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -1,13 +1,11 @@
 //! Style sheet abstraction for tui-markdown.
 //!
-//! The library used to hard–code all color and attribute choices in an internal `styles` module.
-//! That made it impossible for downstream crates to provide their own look-and-feel. The
-//! [`StyleSheet`] trait makes it possible to customize the styles and symbols the renderer uses.
+//! [`StyleSheet`] supplies the styles and alert text used while Markdown events are rendered.
+//! Implementations provide the core heading, code, link, blockquote, and metadata styles. Newer
+//! construct hooks have defaults so existing implementations remain source-compatible.
 //!
-//! Users that are happy with the stock colors do not have to do anything – the crate exports a
-//! [`DefaultStyleSheet`] which matches the old behaviour and is used by default. Projects that want
-//! to theme the output can implement the trait for their own type and pass an instance via
-//! [`crate::Options`].
+//! [`DefaultStyleSheet`] is used by [`crate::Options::default`]. Applications can pass another
+//! implementation to [`crate::Options::new`].
 
 use ratatui_core::style::Style;
 
@@ -41,8 +39,8 @@ impl AlertKind {
 
 /// Visual styles and symbols consumed by the renderer.
 ///
-/// The trait purposefully stays tiny: whenever the renderer needs a presentation choice we add a
-/// new getter here. The default implementation maintains the renderer's standard appearance.
+/// Required methods define the original renderer styles. Methods for newer Markdown constructs have
+/// defaults so adding those hooks did not require downstream implementations to change.
 pub trait StyleSheet: Clone + Send + Sync + 'static {
     /// Style for a Markdown heading.
     ///
@@ -52,7 +50,7 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
     /// Style for inline `code` spans and fenced code blocks when syntax highlighting is disabled.
     fn code(&self) -> Style;
 
-    /// Style for the text of an inline or reference link.
+    /// Style for an inline or reference link's visible label and appended destination.
     fn link(&self) -> Style;
 
     /// Base style applied to blockquotes (`>` prefix and body text).
@@ -78,12 +76,12 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
         Style::new().magenta()
     }
 
-    /// Style for footnote references (`[^label]`).
+    /// Style for footnote references, rendered as `[label]`.
     fn footnote_ref(&self) -> Style {
         Style::new().dim().italic()
     }
 
-    /// Style for footnote definitions.
+    /// Style for footnote definitions, including the `[label]: ` prefix.
     fn footnote_def(&self) -> Style {
         Style::new().dim()
     }
@@ -93,7 +91,7 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
         Style::new().bold()
     }
 
-    /// Style for definition list descriptions.
+    /// Style for definition list descriptions, including the `: ` prefix.
     fn definition_description(&self) -> Style {
         Style::default()
     }
@@ -155,7 +153,7 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
         Style::new().dark_gray()
     }
 
-    /// Style for the marker and text used to represent Markdown images.
+    /// Style for the `[img]` marker and text used to represent Markdown images.
     ///
     /// The default is dim and italic. The renderer patches this over any enclosing inline style.
     fn image_alt(&self) -> Style {


### PR DESCRIPTION
## Summary

Follow up on [#161](https://github.com/joshka/tui-markdown/pull/161) with a documentation and unit-test audit of the reorganized renderer.

- Document the public rendering entrypoints, borrowing behavior, image fallbacks, syntax highlighting, and construct-specific output.
- Correct the documented MSRV and list math support in `mdr`.
- Add focused regressions for style restoration, construct state, ordered-list starts, hard breaks, and block boundaries.
- Use readable `indoc!` fixtures for multiline Markdown inputs.

This changes neither rendering behavior nor the public API. The tests make lifecycle boundaries explicit so future changes to one Markdown construct do not silently affect the next.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo test -p tui-markdown --no-default-features`
- `rustup run 1.88.0 cargo check --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links" cargo doc --workspace --all-features --no-deps`
- `markdownlint-cli2 '**/*.md'`
