### PR TITLE
feat(mdr): expose renderer options

### DIFF
--- a/markdown-reader/README.md
+++ b/markdown-reader/README.md
@@ -29,15 +29,62 @@ mdr --help
 
 A simple markdown reader that uses ratatui to render markdown files.
 
-Usage: mdr [PATH]
+Usage: mdr [OPTIONS] [PATH]
 
 Arguments:
-  [PATH]  The path to the markdown file to read [default: README.md]
+  [PATH]
+          The path to the markdown file to read
+
+          [default: README.md]
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+      --image-fallback <MODE>
+          Text to display in place of Markdown images
+
+          Possible values:
+          - alt-text:         Display the image description, falling back to its URL
+          - url:              Display the image URL
+          - alt-text-and-url: Display the image description and URL
+
+          [default: alt-text]
+
+      --code-theme <THEME>
+          Built-in syntax-highlighting theme (default: base16-ocean-dark)
+
+          Possible values:
+          - base16-eighties-dark: The dark Base16 Eighties theme
+          - base16-mocha-dark:    The dark Base16 Mocha theme
+          - base16-ocean-dark:    The default dark Base16 Ocean theme
+          - base16-ocean-light:   The light Base16 Ocean theme
+          - inspired-github:      The light Inspired GitHub theme
+          - solarized-dark:       The dark Solarized theme
+          - solarized-light:      The light Solarized theme
+
+      --code-theme-file <PATH>
+          Load a custom syntax-highlighting theme from a TextMate .tmTheme file
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 ```
+
+By default, images display their alt text and code uses the Base16 Ocean dark theme. Select a
+different representation for images or a built-in code theme:
+
+```shell
+mdr --image-fallback alt-text-and-url README.md
+mdr --code-theme solarized-dark README.md
+```
+
+Custom syntax-highlighting themes can be loaded from TextMate `.tmTheme` files:
+
+```shell
+mdr --code-theme-file themes/custom.tmTheme README.md
+```
+
+`--code-theme` and `--code-theme-file` are mutually exclusive.
 
 The repository includes a [feature showcase](TEST.md) for manually checking every supported
 Markdown construct:

--- a/markdown-reader/src/main.rs
+++ b/markdown-reader/src/main.rs
@@ -4,10 +4,11 @@ use std::path::{Path, PathBuf};
 
 use clap::builder::styling::AnsiColor;
 use clap::builder::Styles;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use color_eyre::eyre::{eyre, Ok, WrapErr};
 use color_eyre::Result;
 use tracing::{debug, info, Level};
+use tui_markdown::{BuiltinCodeTheme, CodeTheme, ImageFallback, Options};
 
 use crate::app::App;
 use crate::events::Events;
@@ -18,17 +19,19 @@ mod logging;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    let terminal = ratatui::init();
-    let log_events = logging::init_logger(Level::DEBUG)?;
-
     let args = Cli::parse();
-    let path = args.path;
-    let events = Events::new()?;
-    info!("Reading file {:?}", path);
-    let markdown = read_file(&path)?;
-    let text = tui_markdown::from_str(&markdown);
+    let options = args.renderer_options()?;
+    let log_events = logging::init_logger(Level::DEBUG)?;
+    info!("Reading file {:?}", args.path);
+    let markdown = read_file(&args.path)?;
+    let text = tui_markdown::from_str_with_options(&markdown, &options);
     let _height = text.height();
-    let app = App::new(text, &path, events, log_events);
+    let events = Events::new()?;
+
+    // Keep startup errors out of the alternate screen and enter terminal mode only after every
+    // fallible input and configuration step has completed.
+    let terminal = ratatui::init();
+    let app = App::new(text, &args.path, events, log_events);
     let result = app.run(terminal);
     ratatui::restore();
     result
@@ -52,15 +55,108 @@ const HELP_STYLES: Styles = Styles::styled()
     .placeholder(AnsiColor::Green.on_default());
 
 #[derive(Debug, Parser)]
-#[command(author, version, about, styles = HELP_STYLES)]
+#[command(name = "mdr", author, version, about, styles = HELP_STYLES)]
 struct Cli {
     /// The path to the markdown file to read
     #[arg(default_value = "README.md")]
     path: PathBuf,
+
+    /// Text to display in place of Markdown images
+    #[arg(long, value_enum, value_name = "MODE", default_value = "alt-text")]
+    image_fallback: ImageFallbackArg,
+
+    /// Built-in syntax-highlighting theme (default: base16-ocean-dark)
+    #[arg(
+        long,
+        value_enum,
+        value_name = "THEME",
+        conflicts_with = "code_theme_file"
+    )]
+    code_theme: Option<CodeThemeArg>,
+
+    /// Load a custom syntax-highlighting theme from a TextMate .tmTheme file
+    #[arg(long, value_name = "PATH", conflicts_with = "code_theme")]
+    code_theme_file: Option<PathBuf>,
+}
+
+impl Cli {
+    fn renderer_options(&self) -> Result<Options> {
+        let options = Options::default().image_fallback(self.image_fallback.into());
+        let options = if let Some(code_theme) = self.code_theme {
+            options.code_theme(code_theme)
+        } else if let Some(path) = &self.code_theme_file {
+            options.code_theme(CodeTheme::from_file(path)?)
+        } else {
+            options
+        };
+        Ok(options)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum ImageFallbackArg {
+    /// Display the image description, falling back to its URL
+    AltText,
+    /// Display the image URL
+    Url,
+    /// Display the image description and URL
+    AltTextAndUrl,
+}
+
+impl From<ImageFallbackArg> for ImageFallback {
+    fn from(image_fallback: ImageFallbackArg) -> Self {
+        match image_fallback {
+            ImageFallbackArg::AltText => Self::AltText,
+            ImageFallbackArg::Url => Self::Url,
+            ImageFallbackArg::AltTextAndUrl => Self::AltTextAndUrl,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum CodeThemeArg {
+    /// The dark Base16 Eighties theme
+    Base16EightiesDark,
+    /// The dark Base16 Mocha theme
+    Base16MochaDark,
+    /// The default dark Base16 Ocean theme
+    Base16OceanDark,
+    /// The light Base16 Ocean theme
+    Base16OceanLight,
+    /// The light Inspired GitHub theme
+    InspiredGithub,
+    /// The dark Solarized theme
+    SolarizedDark,
+    /// The light Solarized theme
+    SolarizedLight,
+}
+
+impl From<CodeThemeArg> for BuiltinCodeTheme {
+    fn from(code_theme: CodeThemeArg) -> Self {
+        match code_theme {
+            CodeThemeArg::Base16EightiesDark => Self::Base16EightiesDark,
+            CodeThemeArg::Base16MochaDark => Self::Base16MochaDark,
+            CodeThemeArg::Base16OceanDark => Self::Base16OceanDark,
+            CodeThemeArg::Base16OceanLight => Self::Base16OceanLight,
+            CodeThemeArg::InspiredGithub => Self::InspiredGitHub,
+            CodeThemeArg::SolarizedDark => Self::SolarizedDark,
+            CodeThemeArg::SolarizedLight => Self::SolarizedLight,
+        }
+    }
+}
+
+impl From<CodeThemeArg> for CodeTheme {
+    fn from(code_theme: CodeThemeArg) -> Self {
+        BuiltinCodeTheme::from(code_theme).into()
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use clap::CommandFactory;
+
+    use super::*;
+
     #[test]
     fn feature_showcase() {
         let markdown = include_str!("../TEST.md");
@@ -71,5 +167,68 @@ mod tests {
         // across a construct boundary but leaves the visible characters unchanged.
         insta::assert_snapshot!("feature_showcase_text", text);
         insta::assert_debug_snapshot!("feature_showcase_styles", text);
+    }
+
+    #[test]
+    fn image_fallback_modes_select_rendered_content() {
+        let cases = [
+            ("alt-text", "[img] diagram"),
+            ("url", "[img] diagram.png"),
+            ("alt-text-and-url", "[img] diagram (diagram.png)"),
+        ];
+
+        for (mode, expected) in cases {
+            let cli = Cli::try_parse_from(["mdr", "--image-fallback", mode]).unwrap();
+            let options = cli.renderer_options().unwrap();
+            let text = tui_markdown::from_str_with_options("![diagram](diagram.png)", &options);
+            assert_eq!(text.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn every_builtin_code_theme_is_accepted() {
+        let themes = [
+            "base16-eighties-dark",
+            "base16-mocha-dark",
+            "base16-ocean-dark",
+            "base16-ocean-light",
+            "inspired-github",
+            "solarized-dark",
+            "solarized-light",
+        ];
+
+        for theme in themes {
+            let cli = Cli::try_parse_from(["mdr", "--code-theme", theme]).unwrap();
+            let options = cli.renderer_options().unwrap();
+            assert!(options.selected_code_theme().is_some());
+        }
+    }
+
+    #[test]
+    fn built_in_and_file_themes_conflict() {
+        let result = Cli::try_parse_from([
+            "mdr",
+            "--code-theme",
+            "solarized-dark",
+            "--code-theme-file",
+            "custom.tmTheme",
+        ]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn theme_file_errors_include_the_requested_path() {
+        let cli =
+            Cli::try_parse_from(["mdr", "--code-theme-file", "missing-theme.tmTheme"]).unwrap();
+
+        let error = cli.renderer_options().unwrap_err();
+
+        assert!(error.to_string().contains("missing-theme.tmTheme"));
+    }
+
+    #[test]
+    fn help() {
+        insta::assert_snapshot!("help", Cli::command().render_long_help());
     }
 }

--- a/markdown-reader/src/snapshots/mdr__tests__help.snap
+++ b/markdown-reader/src/snapshots/mdr__tests__help.snap
@@ -1,0 +1,45 @@
+---
+source: markdown-reader/src/main.rs
+expression: "Cli::command().render_long_help()"
+---
+A simple markdown reader that uses ratatui to render markdown files.
+
+Usage: mdr [OPTIONS] [PATH]
+
+Arguments:
+  [PATH]
+          The path to the markdown file to read
+          
+          [default: README.md]
+
+Options:
+      --image-fallback <MODE>
+          Text to display in place of Markdown images
+
+          Possible values:
+          - alt-text:         Display the image description, falling back to its URL
+          - url:              Display the image URL
+          - alt-text-and-url: Display the image description and URL
+          
+          [default: alt-text]
+
+      --code-theme <THEME>
+          Built-in syntax-highlighting theme (default: base16-ocean-dark)
+
+          Possible values:
+          - base16-eighties-dark: The dark Base16 Eighties theme
+          - base16-mocha-dark:    The dark Base16 Mocha theme
+          - base16-ocean-dark:    The default dark Base16 Ocean theme
+          - base16-ocean-light:   The light Base16 Ocean theme
+          - inspired-github:      The light Inspired GitHub theme
+          - solarized-dark:       The dark Solarized theme
+          - solarized-light:      The light Solarized theme
+
+      --code-theme-file <PATH>
+          Load a custom syntax-highlighting theme from a TextMate .tmTheme file
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version


### PR DESCRIPTION
## Summary

Expose tui-markdown's image fallback and syntax-highlighting theme options in `mdr`.

Images still show alt text and code still uses Base16 Ocean dark by default. Users can now choose
another representation or bundled theme:

```console
mdr --image-fallback alt-text-and-url README.md
mdr --code-theme solarized-dark README.md
```

Custom TextMate themes can be loaded directly from disk:

```console
mdr --code-theme-file themes/custom.tmTheme README.md
```

`--code-theme` and `--code-theme-file` are mutually exclusive. Input and theme errors are resolved
before `mdr` enters the alternate screen, so configuration failures remain readable in the user's
terminal.

This makes the options introduced in [PR #155](https://github.com/joshka/tui-markdown/pull/155),
[PR #156](https://github.com/joshka/tui-markdown/pull/156),
[PR #158](https://github.com/joshka/tui-markdown/pull/158), and
[PR #159](https://github.com/joshka/tui-markdown/pull/159) available to command-line users.

## Validation

- Snapshot the complete long help as the CLI contract.
- Exercise every image fallback and built-in theme value.
- Check conflicting theme sources and custom-theme error context.
- Run the full workspace test, lint, MSRV, and documentation gates.
