### PR TITLE
fix(renderer): keep styled list content inline

### DIFF
--- a/tui-markdown/src/renderer/list.rs
+++ b/tui-markdown/src/renderer/list.rs
@@ -145,6 +145,35 @@ mod tests {
     }
 
     #[rstest]
+    fn characterize_loose_styled_list_content_below_marker(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            - *Emphasized first item.*
+
+            - **Strong second item.**
+
+            1. **Strong first item.**
+
+            2. *Emphasized second item.*
+        "};
+
+        // Characterization: loose-list paragraphs incorrectly start below their item markers.
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from("- "),
+                Line::from(Span::raw("Emphasized first item.").italic()),
+                Line::from("- "),
+                Line::from(Span::raw("Strong second item.").bold()),
+                Line::default(),
+                Line::from(Span::raw("1. ").light_blue()),
+                Line::from(Span::raw("Strong first item.").bold()),
+                Line::from(Span::raw("2. ").light_blue()),
+                Line::from(Span::raw("Emphasized second item.").italic()),
+            ])
+        );
+    }
+
+    #[rstest]
     fn ordered_list_respects_start_index(_with_tracing: DefaultGuard) {
         let markdown = indoc! {"
             10. Tenth

--- a/tui-markdown/src/renderer/list.rs
+++ b/tui-markdown/src/renderer/list.rs
@@ -145,7 +145,45 @@ mod tests {
     }
 
     #[rstest]
-    fn characterize_loose_styled_list_content_below_marker(_with_tracing: DefaultGuard) {
+    fn styled_list_items_keep_content_on_marker_line(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            - *Emphasis* and **strong**
+            - Before **strong *emphasis*** after
+
+            1. **Strong**
+            2. Before *emphasis* after
+        "};
+
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter([
+                    Span::raw("- "),
+                    Span::raw("Emphasis").italic(),
+                    Span::raw(" and "),
+                    Span::raw("strong").bold(),
+                ]),
+                Line::from_iter([
+                    Span::raw("- "),
+                    Span::raw("Before "),
+                    Span::raw("strong ").bold(),
+                    Span::raw("emphasis").bold().italic(),
+                    Span::raw(" after"),
+                ]),
+                Line::default(),
+                Line::from_iter([Span::raw("1. ").light_blue(), Span::raw("Strong").bold()]),
+                Line::from_iter([
+                    Span::raw("2. ").light_blue(),
+                    Span::raw("Before "),
+                    Span::raw("emphasis").italic(),
+                    Span::raw(" after"),
+                ]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn loose_styled_list_items_keep_first_paragraph_on_marker_line(_with_tracing: DefaultGuard) {
         let markdown = indoc! {"
             - *Emphasized first item.*
 
@@ -156,19 +194,42 @@ mod tests {
             2. *Emphasized second item.*
         "};
 
-        // Characterization: loose-list paragraphs incorrectly start below their item markers.
+        // Regression: loose lists emit paragraph boundaries after their item markers.
         assert_eq!(
             from_str(markdown),
             Text::from_iter([
-                Line::from("- "),
-                Line::from(Span::raw("Emphasized first item.").italic()),
-                Line::from("- "),
-                Line::from(Span::raw("Strong second item.").bold()),
+                Line::from_iter([
+                    Span::raw("- "),
+                    Span::raw("Emphasized first item.").italic(),
+                ]),
+                Line::from_iter([Span::raw("- "), Span::raw("Strong second item.").bold(),]),
                 Line::default(),
-                Line::from(Span::raw("1. ").light_blue()),
-                Line::from(Span::raw("Strong first item.").bold()),
-                Line::from(Span::raw("2. ").light_blue()),
-                Line::from(Span::raw("Emphasized second item.").italic()),
+                Line::from_iter([
+                    Span::raw("1. ").light_blue(),
+                    Span::raw("Strong first item.").bold(),
+                ]),
+                Line::from_iter([
+                    Span::raw("2. ").light_blue(),
+                    Span::raw("Emphasized second item.").italic(),
+                ]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn later_styled_paragraph_in_list_stays_separate(_with_tracing: DefaultGuard) {
+        let markdown = indoc! {"
+            - **First paragraph.**
+
+              *Second paragraph.*
+        "};
+
+        assert_eq!(
+            from_str(markdown),
+            Text::from_iter([
+                Line::from_iter([Span::raw("- "), Span::raw("First paragraph.").bold(),]),
+                Line::default(),
+                Line::from(Span::raw("Second paragraph.").italic()),
             ])
         );
     }

--- a/tui-markdown/src/renderer/mod.rs
+++ b/tui-markdown/src/renderer/mod.rs
@@ -278,6 +278,18 @@ where
     }
 
     fn start_paragraph(&mut self) {
+        // Loose list items emit a paragraph start after the item handler has already written the
+        // marker. Keep only that first paragraph on the marker line; later paragraphs have either
+        // added content or set `needs_newline`.
+        let list_marker_line_is_open = self.list_items.last().is_some_and(|item| {
+            !self.needs_newline
+                && self.text.lines.len() == item.marker_line + 1
+                && self.text.lines[item.marker_line].spans.len() == item.marker_span_count
+        });
+        if list_marker_line_is_open {
+            return;
+        }
+
         // Footnote definitions and loose definition-list descriptions start with a paragraph event
         // after their handlers have already written a visible prefix (`[label]: ` or `: `) to the
         // current line. Skip normal paragraph handling only for that first paragraph so its content


### PR DESCRIPTION
## Summary

- keep the first paragraph of a loose list item on the marker line
- preserve normal blank-line separation for later paragraphs
- cover unordered and ordered items with emphasis, strong text, and nested styling

## Problem

Tight styled list items already rendered inline. Loose lists emit a paragraph-start event after the renderer has written the item marker, so paragraph handling moved the item content onto the next line.

The regression fixture was first run as a passing characterization of that known-bad output, then updated with the implementation to assert the intended inline layout.

## Testing

- `cargo test -p tui-markdown 'renderer::list::tests'`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo test -p tui-markdown --no-default-features`

Closes #88
