### PR TITLE
feat(options): configure Markdown symbols

### DIFF
--- a/tui-markdown/README.md
+++ b/tui-markdown/README.md
@@ -73,6 +73,64 @@ fn options() -> Result<Options, CodeThemeLoadError> {
 [`include_str!`]: https://doc.rust-lang.org/std/macro.include_str.html
 [`BuiltinCodeTheme`]: https://docs.rs/tui-markdown/latest/tui_markdown/enum.BuiltinCodeTheme.html
 
+### Markdown presentation symbols
+
+The renderer normally retains heading markers and frames block code with triple backticks. A custom
+style sheet can replace either symbol with [`StyleSheet::heading_marker()`] and
+[`StyleSheet::code_block_fence()`], or return an empty string to hide it:
+
+```rust
+use ratatui::style::Style;
+use tui_markdown::{from_str_with_options, DefaultStyleSheet, Options, StyleSheet};
+
+#[derive(Clone, Copy)]
+struct MinimalStyleSheet;
+
+impl StyleSheet for MinimalStyleSheet {
+    fn heading(&self, level: u8) -> Style {
+        DefaultStyleSheet.heading(level)
+    }
+
+    fn code(&self) -> Style {
+        DefaultStyleSheet.code()
+    }
+
+    fn link(&self) -> Style {
+        DefaultStyleSheet.link()
+    }
+
+    fn blockquote(&self) -> Style {
+        DefaultStyleSheet.blockquote()
+    }
+
+    fn heading_meta(&self) -> Style {
+        DefaultStyleSheet.heading_meta()
+    }
+
+    fn metadata_block(&self) -> Style {
+        DefaultStyleSheet.metadata_block()
+    }
+
+    fn heading_marker(&self, _level: u8) -> &str {
+        ""
+    }
+
+    fn code_block_fence(&self) -> &str {
+        ""
+    }
+}
+
+let options = Options::new(MinimalStyleSheet);
+let markdown = "# Heading\n\n```text\ncode\n```";
+let text = from_str_with_options(markdown, &options);
+
+assert_eq!(text.to_string(), "Heading\n\ncode");
+```
+
+The code-block fence choice is independent of syntax highlighting and applies to fenced and
+indented code blocks alike. Other presentation symbols, such as list markers, blockquote prefixes,
+image indicators, and table borders, retain their standard output.
+
 ## Status
 
 This is working code, but not every markdown feature is supported. PRs welcome!
@@ -236,6 +294,8 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md).
 [`StyleSheet::table_border()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.table_border
 [`StyleSheet::table_cell()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.table_cell
 [`StyleSheet::table_header()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.table_header
+[`StyleSheet::heading_marker()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.heading_marker
+[`StyleSheet::code_block_fence()`]: https://docs.rs/tui-markdown/latest/tui_markdown/trait.StyleSheet.html#method.code_block_fence
 [`ImageFallback`]: https://docs.rs/tui-markdown/latest/tui_markdown/enum.ImageFallback.html
 
 [Crate badge]: https://img.shields.io/crates/v/tui-markdown?logo=rust&style=for-the-badge

--- a/tui-markdown/src/lib.rs
+++ b/tui-markdown/src/lib.rs
@@ -1,8 +1,8 @@
 //! Convert Markdown into Ratatui [`Text`](ratatui_core::text::Text).
 //!
 //! [`from_str`] renders with the default styles and options. [`from_str_with_options`] accepts an
-//! [`Options`] value for a custom [`StyleSheet`], image fallback mode, and, when the
-//! `highlight-code` feature is enabled, syntax-highlighting theme.
+//! [`Options`] value for custom [`StyleSheet`] styles and symbols, image fallback mode, and, when
+//! the `highlight-code` feature is enabled, syntax-highlighting theme.
 //!
 //! The returned text may borrow from the Markdown input. It contains terminal text and styles only;
 //! image syntax produces a configurable text fallback and does not read or render image resources.

--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -43,6 +43,8 @@ pub enum ImageFallback {
 ///
 /// `S` is the style sheet consulted while Markdown events are rendered. [`Options::default`] uses
 /// [`DefaultStyleSheet`]. Use [`Options::new`] to supply another [`StyleSheet`].
+/// [`StyleSheet::heading_marker`] and [`StyleSheet::code_block_fence`] customize or hide the
+/// corresponding presentation symbols.
 ///
 /// # Example
 ///
@@ -91,7 +93,7 @@ pub enum ImageFallback {
 #[non_exhaustive]
 pub struct Options<S: StyleSheet = DefaultStyleSheet> {
     /// The [`StyleSheet`] implementation that will be consulted every time the renderer needs a
-    /// color choice.
+    /// style or symbol choice.
     pub(crate) styles: S,
     /// The content to render in place of images.
     pub(crate) image_fallback: ImageFallback,

--- a/tui-markdown/src/renderer/code.rs
+++ b/tui-markdown/src/renderer/code.rs
@@ -60,14 +60,20 @@ where
         #[cfg(feature = "highlight-code")]
         self.set_code_highlighter(lang);
 
-        let span = Span::from(format!("```{lang}"));
-        self.push_line(span.into());
+        let fence = self.styles.code_block_fence();
+        if !fence.is_empty() {
+            let span = Span::from(format!("{fence}{lang}"));
+            self.push_line(span.into());
+        }
         self.needs_newline = true;
     }
 
     pub fn end_codeblock(&mut self) {
-        let span = Span::from("```");
-        self.push_line(span.into());
+        let fence = self.styles.code_block_fence();
+        if !fence.is_empty() {
+            let span = Span::from(fence.to_owned());
+            self.push_line(span.into());
+        }
         self.needs_newline = true;
 
         #[cfg(not(feature = "highlight-code"))]
@@ -139,6 +145,40 @@ mod tests {
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
     use crate::renderer::*;
+    use crate::DefaultStyleSheet;
+
+    #[derive(Clone, Copy)]
+    struct CustomCodeBlockFence(&'static str);
+
+    impl StyleSheet for CustomCodeBlockFence {
+        fn heading(&self, level: u8) -> Style {
+            DefaultStyleSheet.heading(level)
+        }
+
+        fn code(&self) -> Style {
+            DefaultStyleSheet.code()
+        }
+
+        fn link(&self) -> Style {
+            DefaultStyleSheet.link()
+        }
+
+        fn blockquote(&self) -> Style {
+            DefaultStyleSheet.blockquote()
+        }
+
+        fn heading_meta(&self) -> Style {
+            DefaultStyleSheet.heading_meta()
+        }
+
+        fn metadata_block(&self) -> Style {
+            DefaultStyleSheet.metadata_block()
+        }
+
+        fn code_block_fence(&self) -> &str {
+            self.0
+        }
+    }
 
     #[cfg_attr(not(feature = "highlight-code"), ignore)]
     #[rstest]
@@ -219,6 +259,48 @@ mod tests {
         let text = from_str(markdown);
 
         assert_eq!(text.lines.last(), Some(&Line::from("After")));
+    }
+
+    #[rstest]
+    fn custom_code_block_fence(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomCodeBlockFence("~~~"));
+        let markdown = "```not-a-language\ncode\n```";
+
+        assert_eq!(
+            from_str_with_options(markdown, &options).to_string(),
+            "~~~not-a-language\ncode\n~~~"
+        );
+    }
+
+    #[rstest]
+    fn empty_code_block_fence_preserves_spacing(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomCodeBlockFence(""));
+        let markdown = "Before\n\n```not-a-language\ncode\n```\n\nAfter";
+
+        assert_eq!(
+            from_str_with_options(markdown, &options).to_string(),
+            "Before\n\ncode\n\nAfter"
+        );
+    }
+
+    #[rstest]
+    fn empty_code_block_fence_applies_to_indented_code(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomCodeBlockFence(""));
+
+        assert_eq!(
+            from_str_with_options("    indented code", &options).to_string(),
+            "indented code"
+        );
+    }
+
+    #[cfg(feature = "highlight-code")]
+    #[rstest]
+    fn empty_code_block_fence_applies_to_highlighted_code(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomCodeBlockFence(""));
+        let markdown = "```rust\nfn main() {}\n```";
+        let text = from_str_with_options(markdown, &options);
+
+        assert_eq!(text.to_string(), "fn main() {}");
     }
 
     #[cfg(feature = "highlight-code")]

--- a/tui-markdown/src/renderer/heading.rs
+++ b/tui-markdown/src/renderer/heading.rs
@@ -71,7 +71,12 @@ where
             HeadingLevel::H6 => 6,
         };
         let style = self.styles.heading(heading_level);
-        let content = format!("{} ", "#".repeat(heading_level as usize));
+        let marker = self.styles.heading_marker(heading_level);
+        let content = if marker.is_empty() {
+            String::new()
+        } else {
+            format!("{marker} ")
+        };
         self.push_line(Line::styled(content, style));
         self.heading_meta = heading_meta.into_option();
         self.needs_newline = false;
@@ -91,11 +96,49 @@ where
 mod tests {
     use indoc::indoc;
     use pretty_assertions::assert_eq;
+    use ratatui_core::style::Style;
     use rstest::rstest;
 
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
     use crate::renderer::*;
+    use crate::DefaultStyleSheet;
+
+    #[derive(Clone, Copy)]
+    struct CustomHeadingMarker;
+
+    impl StyleSheet for CustomHeadingMarker {
+        fn heading(&self, level: u8) -> Style {
+            DefaultStyleSheet.heading(level)
+        }
+
+        fn code(&self) -> Style {
+            DefaultStyleSheet.code()
+        }
+
+        fn link(&self) -> Style {
+            DefaultStyleSheet.link()
+        }
+
+        fn blockquote(&self) -> Style {
+            DefaultStyleSheet.blockquote()
+        }
+
+        fn heading_meta(&self) -> Style {
+            DefaultStyleSheet.heading_meta()
+        }
+
+        fn metadata_block(&self) -> Style {
+            DefaultStyleSheet.metadata_block()
+        }
+
+        fn heading_marker(&self, level: u8) -> &str {
+            match level {
+                1 => "",
+                _ => "§",
+            }
+        }
+    }
 
     #[rstest]
     fn headings(_with_tracing: DefaultGuard) {
@@ -170,6 +213,39 @@ mod tests {
                 Line::default(),
                 Line::from_iter([Span::raw("# "), Span::raw("Second")]).style(h1),
             ])
+        );
+    }
+
+    #[rstest]
+    fn custom_and_empty_heading_markers(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomHeadingMarker);
+        let h1 = Style::new().on_cyan().bold().underlined();
+        let h2 = Style::new().cyan().bold();
+
+        assert_eq!(
+            from_str_with_options("# Hidden\n\n## Custom", &options),
+            Text::from_iter([
+                Line::from("Hidden").style(h1),
+                Line::default(),
+                Line::from_iter(["§ ", "Custom"]).style(h2),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn empty_heading_marker_preserves_attributes(_with_tracing: DefaultGuard) {
+        let options = Options::new(CustomHeadingMarker);
+        let h1 = Style::new().on_cyan().bold().underlined();
+
+        assert_eq!(
+            from_str_with_options("# Heading {#title}", &options),
+            Text::from(
+                Line::from_iter([
+                    Span::raw("Heading"),
+                    Span::styled(" {#title}", Style::new().dim()),
+                ])
+                .style(h1)
+            )
         );
     }
 }

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -61,6 +61,30 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 
     /// Style for metadata blocks (front matter).
     fn metadata_block(&self) -> Style;
+
+    /// Marker displayed before a Markdown heading.
+    ///
+    /// `level` is one-based (`1` for an H1, …). The renderer adds one separating space after a
+    /// non-empty marker. Return an empty string to omit the marker and its separator.
+    fn heading_marker(&self, level: u8) -> &str {
+        match level {
+            1 => "#",
+            2 => "##",
+            3 => "###",
+            4 => "####",
+            5 => "#####",
+            _ => "######",
+        }
+    }
+
+    /// Delimiter displayed above and below block code.
+    ///
+    /// The renderer appends fenced-code info to the opening delimiter. Return an empty string to
+    /// omit both delimiter lines.
+    fn code_block_fence(&self) -> &str {
+        "```"
+    }
+
     /// Style for raw HTML blocks and inline HTML tags.
     fn html(&self) -> Style {
         Style::new().dim()
@@ -174,6 +198,8 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 /// - link: blue, underlined
 /// - blockquote: green
 /// - metadata block: light yellow
+/// - heading markers: one to six `#` characters
+/// - code block fences: three backticks
 /// - raw HTML: dim
 /// - inline math: magenta, italic
 /// - display math: magenta


### PR DESCRIPTION
## Summary

- add defaulted `StyleSheet` hooks for heading markers and code block fences
- allow either symbol to be replaced or hidden without changing default output
- keep fence visibility independent of syntax highlighting and preserve block spacing
- document the API with a complete custom style sheet example

## Scope

This first step intentionally covers only heading markers and code block fences. Other renderer
presentation symbols remain unchanged for now; more hooks can be added later if concrete use cases
need them.

Closes #89.

## Validation

- `cargo test --workspace --all-features`
- `cargo test -p tui-markdown --no-default-features`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p tui-markdown --all-features --no-deps`
- `cargo fmt --all -- --check`
- `markdownlint-cli2 --config .markdownlint-cli2.yaml tui-markdown/README.md`
