### PR TITLE
feat(options): make stylesheet methods optional

### DIFF
--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -65,26 +65,6 @@ pub enum ImageFallback {
 ///     fn heading(&self, _level: u8) -> Style {
 ///         Style::new().bold()
 ///     }
-///
-///     fn code(&self) -> Style {
-///         Style::new().white().on_dark_gray()
-///     }
-///
-///     fn link(&self) -> Style {
-///         Style::new().blue().underlined()
-///     }
-///
-///     fn blockquote(&self) -> Style {
-///         Style::new().yellow()
-///     }
-///
-///     fn heading_meta(&self) -> Style {
-///         Style::new().dim()
-///     }
-///
-///     fn metadata_block(&self) -> Style {
-///         Style::new().light_yellow()
-///     }
 /// }
 ///
 /// let options = Options::new(MyStyleSheet);
@@ -194,26 +174,6 @@ mod tests {
                     _ => Style::new().green(),
                 }
             }
-
-            fn code(&self) -> Style {
-                Style::new().white().on_black()
-            }
-
-            fn link(&self) -> Style {
-                Style::new().blue().underlined()
-            }
-
-            fn blockquote(&self) -> Style {
-                Style::new().yellow()
-            }
-
-            fn heading_meta(&self) -> Style {
-                Style::new().dim()
-            }
-
-            fn metadata_block(&self) -> Style {
-                Style::new().light_yellow()
-            }
         }
 
         let options = Options {
@@ -227,7 +187,7 @@ mod tests {
         assert_eq!(options.styles.heading(2), Style::new().green());
         assert_eq!(options.styles.code(), Style::new().white().on_black());
         assert_eq!(options.styles.link(), Style::new().blue().underlined());
-        assert_eq!(options.styles.blockquote(), Style::new().yellow());
+        assert_eq!(options.styles.blockquote(), Style::new().green());
         assert_eq!(options.styles.heading_meta(), Style::new().dim());
         assert_eq!(options.styles.metadata_block(), Style::new().light_yellow());
         assert_eq!(options.styles.image_alt(), Style::new().dim().italic());

--- a/tui-markdown/src/renderer/blockquote.rs
+++ b/tui-markdown/src/renderer/blockquote.rs
@@ -92,30 +92,6 @@ mod tests {
         struct CustomAlertStyleSheet;
 
         impl StyleSheet for CustomAlertStyleSheet {
-            fn heading(&self, level: u8) -> Style {
-                DefaultStyleSheet.heading(level)
-            }
-
-            fn code(&self) -> Style {
-                DefaultStyleSheet.code()
-            }
-
-            fn link(&self) -> Style {
-                DefaultStyleSheet.link()
-            }
-
-            fn blockquote(&self) -> Style {
-                DefaultStyleSheet.blockquote()
-            }
-
-            fn heading_meta(&self) -> Style {
-                DefaultStyleSheet.heading_meta()
-            }
-
-            fn metadata_block(&self) -> Style {
-                DefaultStyleSheet.metadata_block()
-            }
-
             fn alert(&self, kind: AlertKind) -> Style {
                 match kind {
                     AlertKind::Note => Style::new().on_red(),
@@ -128,30 +104,6 @@ mod tests {
         struct CustomAlertHeadingStyleSheet;
 
         impl StyleSheet for CustomAlertHeadingStyleSheet {
-            fn heading(&self, level: u8) -> Style {
-                DefaultStyleSheet.heading(level)
-            }
-
-            fn code(&self) -> Style {
-                DefaultStyleSheet.code()
-            }
-
-            fn link(&self) -> Style {
-                DefaultStyleSheet.link()
-            }
-
-            fn blockquote(&self) -> Style {
-                DefaultStyleSheet.blockquote()
-            }
-
-            fn heading_meta(&self) -> Style {
-                DefaultStyleSheet.heading_meta()
-            }
-
-            fn metadata_block(&self) -> Style {
-                DefaultStyleSheet.metadata_block()
-            }
-
             fn alert_icon(&self, kind: AlertKind) -> &str {
                 match kind {
                     AlertKind::Note => "!!",

--- a/tui-markdown/src/renderer/code.rs
+++ b/tui-markdown/src/renderer/code.rs
@@ -145,36 +145,11 @@ mod tests {
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
     use crate::renderer::*;
-    use crate::DefaultStyleSheet;
 
     #[derive(Clone, Copy)]
     struct CustomCodeBlockFence(&'static str);
 
     impl StyleSheet for CustomCodeBlockFence {
-        fn heading(&self, level: u8) -> Style {
-            DefaultStyleSheet.heading(level)
-        }
-
-        fn code(&self) -> Style {
-            DefaultStyleSheet.code()
-        }
-
-        fn link(&self) -> Style {
-            DefaultStyleSheet.link()
-        }
-
-        fn blockquote(&self) -> Style {
-            DefaultStyleSheet.blockquote()
-        }
-
-        fn heading_meta(&self) -> Style {
-            DefaultStyleSheet.heading_meta()
-        }
-
-        fn metadata_block(&self) -> Style {
-            DefaultStyleSheet.metadata_block()
-        }
-
         fn code_block_fence(&self) -> &str {
             self.0
         }

--- a/tui-markdown/src/renderer/definition_list.rs
+++ b/tui-markdown/src/renderer/definition_list.rs
@@ -64,7 +64,6 @@ mod tests {
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
     use crate::renderer::*;
-    use crate::*;
 
     mod definition_list {
         use pretty_assertions::assert_eq;
@@ -75,30 +74,6 @@ mod tests {
         struct CustomDefinitionStyleSheet;
 
         impl StyleSheet for CustomDefinitionStyleSheet {
-            fn heading(&self, level: u8) -> Style {
-                DefaultStyleSheet.heading(level)
-            }
-
-            fn code(&self) -> Style {
-                DefaultStyleSheet.code()
-            }
-
-            fn link(&self) -> Style {
-                DefaultStyleSheet.link()
-            }
-
-            fn blockquote(&self) -> Style {
-                DefaultStyleSheet.blockquote()
-            }
-
-            fn heading_meta(&self) -> Style {
-                DefaultStyleSheet.heading_meta()
-            }
-
-            fn metadata_block(&self) -> Style {
-                DefaultStyleSheet.metadata_block()
-            }
-
             fn definition_term(&self) -> Style {
                 Style::new().red().underlined()
             }

--- a/tui-markdown/src/renderer/footnote.rs
+++ b/tui-markdown/src/renderer/footnote.rs
@@ -51,7 +51,6 @@ mod tests {
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
     use crate::renderer::*;
-    use crate::*;
 
     mod footnotes {
         use pretty_assertions::assert_eq;
@@ -215,30 +214,6 @@ mod tests {
             struct CustomFootnoteStyle;
 
             impl StyleSheet for CustomFootnoteStyle {
-                fn heading(&self, level: u8) -> Style {
-                    DefaultStyleSheet.heading(level)
-                }
-
-                fn code(&self) -> Style {
-                    DefaultStyleSheet.code()
-                }
-
-                fn link(&self) -> Style {
-                    DefaultStyleSheet.link()
-                }
-
-                fn blockquote(&self) -> Style {
-                    DefaultStyleSheet.blockquote()
-                }
-
-                fn heading_meta(&self) -> Style {
-                    DefaultStyleSheet.heading_meta()
-                }
-
-                fn metadata_block(&self) -> Style {
-                    DefaultStyleSheet.metadata_block()
-                }
-
                 fn footnote_ref(&self) -> Style {
                     Style::new().red().underlined()
                 }

--- a/tui-markdown/src/renderer/heading.rs
+++ b/tui-markdown/src/renderer/heading.rs
@@ -102,36 +102,11 @@ mod tests {
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
     use crate::renderer::*;
-    use crate::DefaultStyleSheet;
 
     #[derive(Clone, Copy)]
     struct CustomHeadingMarker;
 
     impl StyleSheet for CustomHeadingMarker {
-        fn heading(&self, level: u8) -> Style {
-            DefaultStyleSheet.heading(level)
-        }
-
-        fn code(&self) -> Style {
-            DefaultStyleSheet.code()
-        }
-
-        fn link(&self) -> Style {
-            DefaultStyleSheet.link()
-        }
-
-        fn blockquote(&self) -> Style {
-            DefaultStyleSheet.blockquote()
-        }
-
-        fn heading_meta(&self) -> Style {
-            DefaultStyleSheet.heading_meta()
-        }
-
-        fn metadata_block(&self) -> Style {
-            DefaultStyleSheet.metadata_block()
-        }
-
         fn heading_marker(&self, level: u8) -> &str {
             match level {
                 1 => "",

--- a/tui-markdown/src/renderer/math.rs
+++ b/tui-markdown/src/renderer/math.rs
@@ -44,7 +44,6 @@ mod tests {
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
     use crate::renderer::*;
-    use crate::*;
 
     mod math {
         use pretty_assertions::assert_eq;
@@ -108,30 +107,6 @@ mod tests {
             struct CustomMathStyle;
 
             impl StyleSheet for CustomMathStyle {
-                fn heading(&self, level: u8) -> Style {
-                    DefaultStyleSheet.heading(level)
-                }
-
-                fn code(&self) -> Style {
-                    DefaultStyleSheet.code()
-                }
-
-                fn link(&self) -> Style {
-                    DefaultStyleSheet.link()
-                }
-
-                fn blockquote(&self) -> Style {
-                    DefaultStyleSheet.blockquote()
-                }
-
-                fn heading_meta(&self) -> Style {
-                    DefaultStyleSheet.heading_meta()
-                }
-
-                fn metadata_block(&self) -> Style {
-                    DefaultStyleSheet.metadata_block()
-                }
-
                 fn math_display(&self) -> Style {
                     Style::new().red().bold()
                 }

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -1,8 +1,8 @@
 //! Style sheet abstraction for tui-markdown.
 //!
 //! [`StyleSheet`] supplies the styles and alert text used while Markdown events are rendered.
-//! Implementations provide the core heading, code, link, blockquote, and metadata styles. Newer
-//! construct hooks have defaults so existing implementations remain source-compatible.
+//! Every choice has a default. Implementations only need to override the styles or text they want
+//! to customize.
 //!
 //! [`DefaultStyleSheet`] is used by [`crate::Options::default`]. Applications can pass another
 //! implementation to [`crate::Options::new`].
@@ -39,28 +39,47 @@ impl AlertKind {
 
 /// Visual styles and symbols consumed by the renderer.
 ///
-/// Required methods define the original renderer styles. Methods for newer Markdown constructs have
-/// defaults so adding those hooks did not require downstream implementations to change.
+/// Every method has a default, which [`DefaultStyleSheet`] uses unchanged. Implementations only
+/// need to override the choices they want to customize.
 pub trait StyleSheet: Clone + Send + Sync + 'static {
     /// Style for a Markdown heading.
     ///
     /// `level` is one-based (`1` for `# H1`, …).
-    fn heading(&self, level: u8) -> Style;
+    fn heading(&self, level: u8) -> Style {
+        match level {
+            1 => Style::new().on_cyan().bold().underlined(),
+            2 => Style::new().cyan().bold(),
+            3 => Style::new().cyan().bold().italic(),
+            4 => Style::new().light_cyan().italic(),
+            5 => Style::new().light_cyan().italic(),
+            _ => Style::new().light_cyan().italic(),
+        }
+    }
 
     /// Style for inline `code` spans and fenced code blocks when syntax highlighting is disabled.
-    fn code(&self) -> Style;
+    fn code(&self) -> Style {
+        Style::new().white().on_black()
+    }
 
     /// Style for an inline or reference link's visible label and appended destination.
-    fn link(&self) -> Style;
+    fn link(&self) -> Style {
+        Style::new().blue().underlined()
+    }
 
     /// Base style applied to blockquotes (`>` prefix and body text).
-    fn blockquote(&self) -> Style;
+    fn blockquote(&self) -> Style {
+        Style::new().green()
+    }
 
     /// Style for heading attribute metadata appended to the heading text.
-    fn heading_meta(&self) -> Style;
+    fn heading_meta(&self) -> Style {
+        Style::new().dim()
+    }
 
     /// Style for metadata blocks (front matter).
-    fn metadata_block(&self) -> Style;
+    fn metadata_block(&self) -> Style {
+        Style::new().light_yellow()
+    }
 
     /// Marker displayed before a Markdown heading.
     ///
@@ -219,36 +238,4 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DefaultStyleSheet;
 
-impl StyleSheet for DefaultStyleSheet {
-    fn heading(&self, level: u8) -> Style {
-        match level {
-            1 => Style::new().on_cyan().bold().underlined(),
-            2 => Style::new().cyan().bold(),
-            3 => Style::new().cyan().bold().italic(),
-            4 => Style::new().light_cyan().italic(),
-            5 => Style::new().light_cyan().italic(),
-            _ => Style::new().light_cyan().italic(),
-        }
-    }
-
-    fn code(&self) -> Style {
-        Style::new().white().on_black()
-    }
-
-    fn link(&self) -> Style {
-        Style::new().blue().underlined()
-    }
-
-    fn blockquote(&self) -> Style {
-        Style::new().green()
-    }
-
-    fn heading_meta(&self) -> Style {
-        // De-emphasize metadata so the heading text stays primary.
-        Style::new().dim()
-    }
-
-    fn metadata_block(&self) -> Style {
-        Style::new().light_yellow()
-    }
-}
+impl StyleSheet for DefaultStyleSheet {}


### PR DESCRIPTION
## Summary

- give every `StyleSheet` method its existing `DefaultStyleSheet` value as a trait default
- let custom style sheets override only the choices they need
- keep the canonical renderer output unchanged and simplify focused examples and tests

## Rationale

`StyleSheet` is a customization policy rather than a contract where every choice must be supplied. Each method already has an unambiguous canonical value, so requiring downstream implementations to repeat unrelated defaults adds boilerplate without providing additional correctness.

The tradeoff is that accidentally omitting an intended override now compiles, but that matches the trait's opt-in customization model and makes future style hooks source-compatible by construction.

## Validation

- `cargo test --workspace --all-features`
- `cargo test -p tui-markdown --no-default-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
