### PR TITLE
Catch clippy regressions before stable

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,6 +72,24 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
 
+  clippy-beta:
+    name: Clippy (beta, non-blocking)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: beta
+          components: clippy
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+
   check:
     name: Check Targets
     runs-on: ubuntu-latest

--- a/tui-markdown/src/renderer/blockquote.rs
+++ b/tui-markdown/src/renderer/blockquote.rs
@@ -76,12 +76,12 @@ fn alert_kind(kind: BlockQuoteKind) -> AlertKind {
 #[cfg(test)]
 mod tests {
     use indoc::{formatdoc, indoc};
+    use ratatui_core::text::Text;
     use rstest::rstest;
 
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
-    use crate::renderer::*;
-    use crate::*;
+    use crate::{from_str, from_str_with_options, DefaultStyleSheet, Options};
 
     mod gfm_alerts {
         use pretty_assertions::assert_eq;

--- a/tui-markdown/src/renderer/code.rs
+++ b/tui-markdown/src/renderer/code.rs
@@ -140,11 +140,12 @@ where
 mod tests {
     use indoc::indoc;
     use pretty_assertions::assert_eq;
+    use ratatui_core::style::Style;
     use rstest::rstest;
 
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
-    use crate::renderer::*;
+    use crate::{from_str, from_str_with_options, Options};
 
     #[derive(Clone, Copy)]
     struct CustomCodeBlockFence(&'static str);

--- a/tui-markdown/src/renderer/definition_list.rs
+++ b/tui-markdown/src/renderer/definition_list.rs
@@ -59,11 +59,12 @@ where
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
+    use ratatui_core::{style::Style, text::Text};
     use rstest::rstest;
 
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
-    use crate::renderer::*;
+    use crate::{from_str, from_str_with_options, Options};
 
     mod definition_list {
         use pretty_assertions::assert_eq;

--- a/tui-markdown/src/renderer/footnote.rs
+++ b/tui-markdown/src/renderer/footnote.rs
@@ -46,11 +46,12 @@ where
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
+    use ratatui_core::{style::Style, text::Text};
     use rstest::rstest;
 
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
-    use crate::renderer::*;
+    use crate::{from_str, from_str_with_options, Options};
 
     mod footnotes {
         use pretty_assertions::assert_eq;

--- a/tui-markdown/src/renderer/formatting.rs
+++ b/tui-markdown/src/renderer/formatting.rs
@@ -34,11 +34,12 @@ where
 mod tests {
     use pretty_assertions::assert_eq;
     use ratatui_core::style::Stylize;
+    use ratatui_core::text::{Line, Span, Text};
     use rstest::rstest;
 
     use super::*;
+    use crate::from_str;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
-    use crate::renderer::*;
 
     #[rstest]
     fn superscript(_with_tracing: DefaultGuard) {

--- a/tui-markdown/src/renderer/heading.rs
+++ b/tui-markdown/src/renderer/heading.rs
@@ -96,12 +96,12 @@ where
 mod tests {
     use indoc::indoc;
     use pretty_assertions::assert_eq;
-    use ratatui_core::style::Style;
+    use ratatui_core::{style::Style, text::Text};
     use rstest::rstest;
 
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
-    use crate::renderer::*;
+    use crate::{from_str, from_str_with_options, Options};
 
     #[derive(Clone, Copy)]
     struct CustomHeadingMarker;

--- a/tui-markdown/src/renderer/html.rs
+++ b/tui-markdown/src/renderer/html.rs
@@ -50,11 +50,12 @@ where
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
+    use ratatui_core::{style::Style, text::Text};
     use rstest::rstest;
 
     use super::*;
+    use crate::from_str;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
-    use crate::renderer::*;
 
     mod html {
         use pretty_assertions::assert_eq;

--- a/tui-markdown/src/renderer/image.rs
+++ b/tui-markdown/src/renderer/image.rs
@@ -117,12 +117,13 @@ where
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
+    use itertools::Itertools;
+    use ratatui_core::text::{Line, Text};
     use rstest::rstest;
 
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
-    use crate::renderer::*;
-    use crate::*;
+    use crate::{from_str, from_str_with_options, DefaultStyleSheet, Options};
 
     mod image {
         use pretty_assertions::assert_eq;

--- a/tui-markdown/src/renderer/link.rs
+++ b/tui-markdown/src/renderer/link.rs
@@ -37,11 +37,15 @@ where
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
+    use ratatui_core::{
+        style::Style,
+        text::{Line, Text},
+    };
     use rstest::rstest;
 
     use super::*;
+    use crate::from_str;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
-    use crate::renderer::*;
 
     #[rstest]
     fn link_uses_default_style(_with_tracing: DefaultGuard) {

--- a/tui-markdown/src/renderer/math.rs
+++ b/tui-markdown/src/renderer/math.rs
@@ -39,11 +39,12 @@ where
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
+    use ratatui_core::{style::Style, text::Text};
     use rstest::rstest;
 
     use super::*;
     use crate::renderer::test_support::{with_tracing, DefaultGuard};
-    use crate::renderer::*;
+    use crate::{from_str, from_str_with_options, Options};
 
     mod math {
         use pretty_assertions::assert_eq;


### PR DESCRIPTION
## Summary

- replace broad renderer and crate glob imports in unit tests with explicit imports while retaining the conventional `super::*`
- add a beta-toolchain clippy job labeled non-blocking and keep it outside the required merge gate

## Context

Rust 1.98 began reporting redundant test-module imports under the workspace's warnings-as-errors clippy check. Running the same check on beta provides advance warning when a future stable release introduces similar diagnostics.

## Validation

- `cargo clippy --all-targets --all-features --workspace -- -D warnings` on Rust 1.98
- the same clippy command on Rust 1.99 beta
- `cargo test --all-features --workspace`
- `actionlint -color=false .github/workflows/check.yml`
