### PR TITLE
feat(renderer): add StyleSheet::list_marker for ordered list markers

### DIFF
--- a/tui-markdown/src/options.rs
+++ b/tui-markdown/src/options.rs
@@ -191,6 +191,7 @@ mod tests {
         assert_eq!(options.styles.heading_meta(), Style::new().dim());
         assert_eq!(options.styles.metadata_block(), Style::new().light_yellow());
         assert_eq!(options.styles.image_alt(), Style::new().dim().italic());
+        assert_eq!(options.styles.list_marker(), Style::new().light_blue());
     }
 
     #[test]

--- a/tui-markdown/src/renderer/list.rs
+++ b/tui-markdown/src/renderer/list.rs
@@ -1,7 +1,6 @@
 //! Markdown list and task-item rendering.
 
 use pulldown_cmark::Event;
-use ratatui_core::style::Stylize;
 use ratatui_core::text::{Line, Span};
 
 use super::TextWriter;
@@ -55,7 +54,10 @@ where
                 None => Span::from(" ".repeat(width - 1) + "- "),
                 Some(index) => {
                     *index += 1;
-                    format!("{:width$}. ", *index - 1).light_blue()
+                    Span::styled(
+                        format!("{:width$}. ", *index - 1),
+                        self.styles.list_marker(),
+                    )
                 }
             };
             let continuation_width = span.width();
@@ -100,6 +102,7 @@ where
 mod tests {
     use indoc::indoc;
     use pretty_assertions::assert_eq;
+    use ratatui_core::style::Stylize;
     use rstest::rstest;
 
     use super::*;
@@ -307,6 +310,60 @@ mod tests {
                 Line::default(),
                 Line::from("After"),
             ])
+        );
+    }
+
+    #[rstest]
+    fn ordered_list_marker_uses_style_sheet(_with_tracing: DefaultGuard) {
+        #[derive(Clone, Copy)]
+        struct CustomListMarkerStyle;
+
+        impl StyleSheet for CustomListMarkerStyle {
+            fn list_marker(&self) -> Style {
+                Style::new().magenta().bold()
+            }
+        }
+
+        let markdown = indoc! {"
+            1. List item 1
+            2. List item 2
+        "};
+        let options = Options::new(CustomListMarkerStyle);
+        assert_eq!(
+            from_str_with_options(markdown, &options),
+            Text::from_iter([
+                Line::from_iter([
+                    Span::styled("1. ", Style::new().magenta().bold()),
+                    Span::raw("List item 1"),
+                ]),
+                Line::from_iter([
+                    Span::styled("2. ", Style::new().magenta().bold()),
+                    Span::raw("List item 2"),
+                ]),
+            ])
+        );
+    }
+
+    #[rstest]
+    fn unordered_list_marker_is_not_affected_by_style_sheet(_with_tracing: DefaultGuard) {
+        #[derive(Clone, Copy)]
+        struct CustomListMarkerStyle;
+
+        impl StyleSheet for CustomListMarkerStyle {
+            fn list_marker(&self) -> Style {
+                Style::new().magenta().bold()
+            }
+        }
+
+        let markdown = indoc! {"
+            - List item 1
+        "};
+        let options = Options::new(CustomListMarkerStyle);
+        assert_eq!(
+            from_str_with_options(markdown, &options),
+            Text::from_iter([Line::from_iter(
+                [Span::raw("- "), Span::raw("List item 1"),]
+            ),])
         );
     }
 }

--- a/tui-markdown/src/style_sheet.rs
+++ b/tui-markdown/src/style_sheet.rs
@@ -196,6 +196,13 @@ pub trait StyleSheet: Clone + Send + Sync + 'static {
         Style::new().dark_gray()
     }
 
+    /// Style for ordered list markers (`1.`, `2.`, ...)
+    ///
+    /// This changes the presentation of the ordered list marker, not the marker text itself.
+    fn list_marker(&self) -> Style {
+        Style::new().light_blue()
+    }
+
     /// Style for the `[img]` marker and text used to represent Markdown images.
     ///
     /// The default is dim and italic. The renderer patches this over any enclosing inline style.


### PR DESCRIPTION
Closes #179 

## Summary

Ordered list markers are hardcoded to `light_blue` in `renderer/list.rs`, so they
can't be themed. `Text::style` can't override them either, since span styles patch
over the base style. Unordered markers are unstyled and correctly inherit, so the
two marker kinds behave differently for no stated reason.

## Changes

Adds `StyleSheet::list_marker()`, defaulting to `Style::new().light_blue()`, and
uses it in `start_item`. `self.styles` was already available on `TextWriter`, so
no signature changes were needed.

## Backwards compatibility

Not a breaking change. The existing `list_ordered` test passes untouched, snapshots
are unchanged, and the default is now pinned in the `options.rs` defaults test.